### PR TITLE
Fix API errors

### DIFF
--- a/src/services/contract.service.js
+++ b/src/services/contract.service.js
@@ -39,12 +39,7 @@ const ContractService = {
           return resolve(contract);
         })
         .catch(error => {
-          reject(
-            new ContractError(
-              error.response.status,
-              error.response.data.non_field_errors[0]
-            )
-          );
+          reject(error);
         });
     });
   },
@@ -85,12 +80,7 @@ const ContractService = {
           return resolve(contract);
         })
         .catch(error => {
-          reject(
-            new ContractError(
-              error.response.status,
-              error.response.data.non_field_errors[0]
-            )
-          );
+          reject(error);
         });
     });
   },
@@ -101,9 +91,7 @@ const ContractService = {
           return resolve(response);
         })
         .catch(error => {
-          reject(
-            new ContractError(error.response.status, error.response.data.detail)
-          );
+          reject(error);
         });
     });
   }

--- a/src/services/shift.service.js
+++ b/src/services/shift.service.js
@@ -41,12 +41,7 @@ const ShiftService = {
           return resolve(shift);
         })
         .catch(error => {
-          reject(
-            new ShiftError(
-              error.response.status,
-              error.response.data.non_field_errors[0]
-            )
-          );
+          reject(error);
         });
     });
   },
@@ -87,12 +82,7 @@ const ShiftService = {
           return resolve(shift);
         })
         .catch(error => {
-          reject(
-            new ShiftError(
-              error.response.status,
-              error.response.data.non_field_errors[0]
-            )
-          );
+          reject(error);
         });
     });
   },
@@ -103,9 +93,7 @@ const ShiftService = {
           return resolve(response);
         })
         .catch(error => {
-          reject(
-            new ShiftError(error.response.status, error.response.data.detail)
-          );
+          reject(error);
         });
     });
   }

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -81,9 +81,7 @@ const UserService = {
           resolve();
         })
         .catch(error => {
-          reject(
-            new AuthenticationError(error.response.status, error.response.data)
-          );
+          reject(error);
         });
     });
   },


### PR DESCRIPTION
- Stop trying to access the error message. Instead, propagate the error further.

We might need to change this in the future again, QUICK FIX!

Resolves #34.