### PR TITLE
Refactor shift list

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "v-mask": "2.0.2",
     "vue": "2.6.11",
     "vue-router": "3.1.3",
+    "vue-undraw": "^2.0.13",
     "vuelidate": "0.7.4",
     "vuetify": "2.2.3",
     "vuex": "3.1.2",

--- a/src/components/shifts/ShiftList.vue
+++ b/src/components/shifts/ShiftList.vue
@@ -3,13 +3,13 @@
     <v-subheader>
       <v-checkbox
         v-if="editable"
+        data-cy="shift-list-toggle-all"
         :disabled="!editable"
         :value="hasSelectedAllShifts"
         :indeterminate="isIndeterminate"
         @change="toggle"
       ></v-checkbox>
-      <!-- <span class="ml-6"> -->
-      <span :class="{ 'ml-6': editable }">
+      <span :class="{ 'ml-6': editable }" data-cy="shift-list-header">
         {{ title | formatHeader }}
         <br />
         Work time sum: {{ totalDuration | minutesToDuration }} /
@@ -17,10 +17,16 @@
       </span>
     </v-subheader>
 
-    <v-list-item-group v-model="selected" multiple color="primary">
+    <v-list-item-group
+      v-model="selected"
+      data-cy="shift-list-group"
+      multiple
+      color="primary"
+    >
       <template v-for="(item, index) in shifts">
         <ShiftListItem
           :key="index"
+          :data-cy="'shift-list-item-' + index"
           :editable="editable"
           :item="item"
           :active="active"

--- a/src/components/shifts/ShiftList.vue
+++ b/src/components/shifts/ShiftList.vue
@@ -1,0 +1,141 @@
+<template>
+  <v-list>
+    <v-subheader>
+      <v-checkbox
+        v-if="editable"
+        :disabled="!editable"
+        :value="hasSelectedAllShifts"
+        :indeterminate="isIndeterminate"
+        @change="toggle"
+      ></v-checkbox>
+      <!-- <span class="ml-6"> -->
+      <span :class="{ 'ml-6': editable }">
+        {{ title | formatHeader }}
+        <br />
+        Work time sum: {{ totalDuration | minutesToDuration }} /
+        {{ debit | hoursToWorktime }}
+      </span>
+    </v-subheader>
+
+    <v-list-item-group v-model="selected" multiple color="primary">
+      <template v-for="(item, index) in shifts">
+        <ShiftListItem
+          :key="index"
+          :editable="editable"
+          :item="item"
+          :active="active"
+          :toggle="toggle"
+        />
+      </template>
+
+      <v-divider v-if="index + 1 < shifts.length" :key="index"></v-divider>
+    </v-list-item-group>
+  </v-list>
+</template>
+
+<script>
+import { format } from "date-fns";
+
+import { mapGetters } from "vuex";
+
+import { minutesToHHMM } from "@/utils/time";
+import ShiftListItem from "@/components/shifts/ShiftListItem";
+
+export default {
+  name: "ShiftList",
+  filters: {
+    formatHeader(text) {
+      const [year, month] = text.split(" ");
+      const date = new Date(year, month - 1, 1);
+
+      return format(date, "MMMM yyyy");
+    },
+    minutesToDuration(value) {
+      return minutesToHHMM(value);
+    },
+    hoursToWorktime(value) {
+      const hours = Math.floor(value);
+      const minutes = parseInt((60 * (value - hours)).toFixed(0));
+
+      return `${hours.pad(2)}:${minutes.pad(2)}`;
+    }
+  },
+  components: { ShiftListItem },
+  props: {
+    editable: {
+      type: Boolean,
+      required: true
+    },
+    shifts: {
+      type: Object,
+      required: true
+    },
+    title: {
+      type: String,
+      required: true
+    }
+  },
+  data: () => ({
+    selected: []
+  }),
+  computed: {
+    ...mapGetters({
+      selectedContract: "selectedContract"
+    }),
+    debit() {
+      return this.selectedContract.hours.toFixed(1);
+    },
+    totalDuration() {
+      return this.shifts.reduce((acc, current) => acc + current.duration, 0);
+    },
+    hasSelectedShifts() {
+      return this.selected.length > 0;
+    },
+    hasSelectedAllShifts() {
+      return this.selected.length === this.shifts.length;
+    },
+    isIndeterminate() {
+      return this.hasSelectedShifts && !this.hasSelectedAllShifts;
+    }
+  },
+  watch: {
+    editable: function(newValue, oldValue) {
+      // noop if oldValue is undefined (=component just initialized)
+      if (oldValue === undefined) return;
+
+      // deselect everything, when we exit edit mode
+      if (newValue !== true) {
+        this.deselectAll();
+      }
+    },
+    selected: function(newValue, oldValue) {
+      // If we did not just initialize and the length is zero: reset
+      if (oldValue.length !== 0 && newValue.length === 0) {
+        this.$emit("resetSelection");
+        return;
+      }
+
+      // If length is bigger than zero, communicate new selection
+      if (newValue.length > 0) {
+        this.$emit("newSelection", this.selected);
+        return;
+      }
+    }
+  },
+  methods: {
+    deselectAll() {
+      this.selected = [];
+    },
+    selectAll() {
+      this.selected = Array(...Array(this.shifts.length)).map((_, i) => i);
+    },
+    toggle() {
+      if (this.hasSelectedAllShifts) {
+        this.deselectAll();
+      } else {
+        this.selectAll();
+      }
+    }
+  }
+};
+</script>

--- a/src/components/shifts/ShiftListItem.vue
+++ b/src/components/shifts/ShiftListItem.vue
@@ -16,6 +16,7 @@
         </v-list-item-subtitle>
         <v-list-item-subtitle>
           <v-chip
+            data-cy="shift-list-item-type"
             outlined
             small
             class="my-2"
@@ -29,6 +30,7 @@
           <v-chip
             v-for="(tag, i) in item.tags"
             :key="tag"
+            :data-cy="'shift-list-item-tag-' + i"
             outlined
             small
             class="my-2"

--- a/src/components/shifts/ShiftListItem.vue
+++ b/src/components/shifts/ShiftListItem.vue
@@ -16,7 +16,18 @@
         </v-list-item-subtitle>
         <v-list-item-subtitle>
           <v-chip
-            v-for="tag in item.tags"
+            outlined
+            small
+            class="my-2"
+            :color="typeColor"
+          >
+            {{ item.type.text }}
+          </v-chip>
+
+          <span v-if="item.tags.length > 0">&nbsp;&mdash;&nbsp;</span>
+
+          <v-chip
+            v-for="(tag, i) in item.tags"
             :key="tag"
             outlined
             small
@@ -32,6 +43,12 @@
 
 <script>
 import { format } from "date-fns";
+
+const TYPE_COLORS = {
+  st: "primary",
+  sk: "red",
+  vn: "green"
+};
 
 export default {
   name: "ShiftListItem",
@@ -54,6 +71,11 @@ export default {
     item: {
       type: Object,
       required: true
+    }
+  },
+  computed: {
+    typeColor() {
+      return TYPE_COLORS[this.item.type.value];
     }
   },
   methods: {

--- a/src/components/shifts/ShiftListItem.vue
+++ b/src/components/shifts/ShiftListItem.vue
@@ -1,0 +1,70 @@
+<template>
+  <v-list-item @click="click">
+    <template v-slot:default="{ active }">
+      <v-list-item-action v-if="editable">
+        <v-checkbox :disabled="!editable" :value="active"></v-checkbox>
+      </v-list-item-action>
+
+      <v-list-item-content>
+        <v-list-item-title>
+          {{ item.date.start | formatDay }}
+        </v-list-item-title>
+        <v-list-item-subtitle class="text--primary">
+          {{ item.date.start | formatTime }} -
+          {{ item.date.end | formatTime }}
+          ({{ item.representationalDuration("hm") }})
+        </v-list-item-subtitle>
+        <v-list-item-subtitle>
+          <v-chip
+            v-for="tag in item.tags"
+            :key="tag"
+            outlined
+            small
+            class="my-2"
+          >
+            {{ tag }}
+          </v-chip>
+        </v-list-item-subtitle>
+      </v-list-item-content>
+    </template>
+  </v-list-item>
+</template>
+
+<script>
+import { format } from "date-fns";
+
+export default {
+  name: "ShiftListItem",
+  filters: {
+    formatDay(date) {
+      return format(date, "EEEE',' do");
+    },
+    formatDate(date) {
+      return format(date, "dd'.'MM'.' HH':'mm");
+    },
+    formatTime(date) {
+      return format(date, "HH':'mm");
+    }
+  },
+  props: {
+    editable: {
+      type: Boolean,
+      required: true
+    },
+    item: {
+      type: Object,
+      required: true
+    }
+  },
+  methods: {
+    click() {
+      if (this.editable) return;
+
+      this.$router.push({
+        name: "editShift",
+        params: { uuid: this.item.uuid }
+      });
+    }
+  }
+};
+</script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -22,7 +22,8 @@ export default new Vuex.Store({
     backendOffline: false
   },
   getters: {
-    getField
+    getField,
+    selectedContract: state => state.selectedContract
   },
   actions: {
     toggleBackend({ commit }) {

--- a/src/store/modules/shift.js
+++ b/src/store/modules/shift.js
@@ -165,7 +165,7 @@ const actions = {
   },
   async queryShifts({ commit }) {
     state.status = "loading";
-    await ShiftService.list()
+    return await ShiftService.list()
       .then(response => {
         commit("setShifts", response.data);
       })
@@ -175,7 +175,7 @@ const actions = {
       });
   },
   async queryClockedShift({ commit }) {
-    await ClockService.get()
+    return await ClockService.get()
       .then(response => {
         let { data } = response;
         if (data !== undefined) {

--- a/src/store/modules/shift.js
+++ b/src/store/modules/shift.js
@@ -15,6 +15,7 @@ const state = {
 
 const getters = {
   getField,
+  shifts: state => state.shifts,
   stagedShift: state => {
     return state.stagedShift;
   },
@@ -24,6 +25,11 @@ const getters = {
   currentShifts: state => {
     return state.shifts.filter(shift =>
       isThisMonth(parseISO(shift.date.start))
+    );
+  },
+  shiftsOfContract: (state, getters, rootState) => {
+    return state.shifts.filter(
+      shift => shift.contract === rootState.selectedContract.uuid
     );
   },
   loading: () => state.status === "loading"

--- a/src/views/ViewShiftList.vue
+++ b/src/views/ViewShiftList.vue
@@ -92,7 +92,7 @@
         top
         right
         color="secondary"
-        data-cy="calendar-create-button"
+        data-cy="shift-create-button"
         :to="{ name: 'createShift' }"
       >
         <v-icon>{{ icons.mdiPlus }}</v-icon>

--- a/src/views/ViewShiftList.vue
+++ b/src/views/ViewShiftList.vue
@@ -2,16 +2,23 @@
   <div>
     <v-skeleton-loader
       v-if="loading"
+      data-cy="shift-list-skeleton"
       loading="true"
       transition="fade-transition"
       type="table"
     >
     </v-skeleton-loader>
 
-    <div v-else-if="shiftsOfContract.length > 0">
-      <v-btn icon @click="toggleEdit">
-        <v-icon v-if="!editable">{{ icons.mdiPencil }}</v-icon>
-        <v-icon v-else>{{ icons.mdiPencilOff }}</v-icon>
+    <div v-else-if="shiftsOfContract.length > 0" data-cy="shift-lists">
+      <v-btn
+        data-cy="shift-list-edit-mode-button"
+        text
+        :outlined="editable"
+        @click="toggleEdit"
+      >
+        <v-icon v-if="!editable" left>{{ icons.mdiPencil }}</v-icon>
+        <v-icon v-else left>{{ icons.mdiPencilOff }}</v-icon>
+        Edit mode
       </v-btn>
 
       <v-dialog v-model="dialog" max-width="500px">
@@ -19,7 +26,7 @@
           <v-slide-x-transition>
             <v-btn
               v-if="editable"
-              data-cy="shift-delete"
+              data-cy="shift-list-delete-button"
               text
               :disabled="deleteDisabled"
               v-on="on"
@@ -54,6 +61,7 @@
       <ShiftList
         v-for="(shifts, key) in shiftsByMonth"
         :key="key"
+        :data-cy="'shift-list-' + key"
         :title="key"
         :shifts="shifts"
         :editable="editable"
@@ -62,7 +70,10 @@
       />
     </div>
 
-    <div v-else-if="shiftsOfContract.length === 0">
+    <div
+      v-else-if="shiftsOfContract.length === 0"
+      data-cy="shift-list-empty-placeholder"
+    >
       <v-container fluid>
         <v-row justify="center">
           <p>You have not created any shifts yet. Get to work!</p>

--- a/src/views/ViewShiftList.vue
+++ b/src/views/ViewShiftList.vue
@@ -122,10 +122,10 @@ export default {
   data: () => ({
     dialog: false,
     editable: false,
-    shiftsByMonth: null,
     icons: { mdiPlus, mdiDelete, mdiDeleteOff, mdiPencil, mdiPencilOff },
     toDelete: null, // We do not want to watch this object, so we use a slightly different solution,
-    shiftsToDelete: []
+    shiftsToDelete: [],
+    unsortedShifts: []
   }),
   computed: {
     ...mapGetters({
@@ -134,6 +134,15 @@ export default {
       selectedContract: "selectedContract",
       shiftsOfContract: "shift/shiftsOfContract"
     }),
+    shiftsByMonth() {
+      return datesGroupByComponent(this.sortedShifts, "y MM");
+    },
+    sortedShifts() {
+      const unsorted = [...this.unsortedShifts];
+      return unsorted.sort((a, b) => {
+        return new Date(b.date.start) - new Date(a.date.start);
+      });
+    },
     deleteDisabled() {
       return this.shiftsToDelete.length === 0;
     },
@@ -186,10 +195,7 @@ export default {
     },
     groupShiftsByMonth() {
       this.$store.dispatch("shift/queryShifts").then(() => {
-        this.shiftsByMonth = datesGroupByComponent(
-          this.shiftsOfContract,
-          "y MM"
-        );
+        this.unsortedShifts = this.shiftsOfContract;
       });
     },
     handleSelection(key, event) {

--- a/src/views/ViewShiftList.vue
+++ b/src/views/ViewShiftList.vue
@@ -1,21 +1,208 @@
 <template>
-  <ShiftListFrame>
-    <FrameHooks
-      slot-scope="{ shifts, methods: { fetchList }, status: { loading } }"
-      @created="fetchList()"
+  <div>
+    <v-skeleton-loader
+      v-if="loading"
+      loading="true"
+      transition="fade-transition"
+      type="table"
     >
-      <ShiftTable :loading="loading" :shifts="shifts" @delete="fetchList()" />
-    </FrameHooks>
-  </ShiftListFrame>
+    </v-skeleton-loader>
+
+    <div v-else-if="shiftsOfContract.length > 0">
+      <v-btn icon @click="toggleEdit">
+        <v-icon v-if="!editable">{{ icons.mdiPencil }}</v-icon>
+        <v-icon v-else>{{ icons.mdiPencilOff }}</v-icon>
+      </v-btn>
+
+      <v-dialog v-model="dialog" max-width="500px">
+        <template v-slot:activator="{ on }">
+          <v-slide-x-transition>
+            <v-btn
+              v-if="editable"
+              data-cy="shift-delete"
+              text
+              :disabled="deleteDisabled"
+              v-on="on"
+            >
+              {{ deleteLabel }}
+            </v-btn>
+          </v-slide-x-transition>
+        </template>
+
+        <v-card data-cy="delete-dialog">
+          <v-card-title>
+            <span class="headline">Delete shifts?</span>
+          </v-card-title>
+
+          <v-card-text>
+            Are you sure you want to delete the selected shifts? This action is
+            permanent.
+          </v-card-text>
+
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn data-cy="delete-confirm" color="error" text @click="destroy">
+              Delete
+            </v-btn>
+            <v-btn data-cy="delete-cancel" text @click="dialog = false">
+              Cancel
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+
+      <ShiftList
+        v-for="(shifts, key) in shiftsByMonth"
+        :key="key"
+        :title="key"
+        :shifts="shifts"
+        :editable="editable"
+        @newSelection="handleSelection(key, $event)"
+        @resetSelection="resetSelection(key)"
+      />
+    </div>
+
+    <div v-else-if="shiftsOfContract.length === 0">
+      <v-container fluid>
+        <v-row justify="center">
+          <p>You have not created any shifts yet. Get to work!</p>
+        </v-row>
+        <v-row justify="center">
+          <UndrawWorkTime height="200" />
+        </v-row>
+      </v-container>
+    </div>
+
+    <portal to="fab">
+      <v-btn
+        absolute
+        dark
+        fab
+        top
+        right
+        color="secondary"
+        data-cy="calendar-create-button"
+        :to="{ name: 'createShift' }"
+      >
+        <v-icon>{{ icons.mdiPlus }}</v-icon>
+      </v-btn>
+    </portal>
+  </div>
 </template>
 
 <script>
-import ShiftListFrame from "@/components/shifts/ShiftListFrame";
-import ShiftTable from "@/components/shifts/ShiftTable";
-import FrameHooks from "@/components/FrameHooks";
+import ShiftList from "@/components/shifts/ShiftList";
+import UndrawWorkTime from "vue-undraw/UndrawWorkTime";
+
+import { mapGetters } from "vuex";
+import {
+  mdiPlus,
+  mdiDelete,
+  mdiDeleteOff,
+  mdiPencil,
+  mdiPencilOff
+} from "@mdi/js";
+
+import { format, parseISO } from "date-fns";
+import { Shift } from "@/models/ShiftModel";
+import ShiftService from "@/services/shift";
+import { handleApiError } from "@/utils/interceptors";
+
+function datesGroupByComponent(dates, token) {
+  return dates.reduce(function(val, obj) {
+    let comp = format(parseISO(obj["date"]["start"]), token);
+    (val[comp] = val[comp] || []).push(new Shift(obj));
+    return val;
+  }, {});
+}
 
 export default {
   name: "ViewShiftList",
-  components: { ShiftListFrame, ShiftTable, FrameHooks }
+  components: { ShiftList, UndrawWorkTime },
+  data: () => ({
+    dialog: false,
+    editable: false,
+    shiftsByMonth: null,
+    icons: { mdiPlus, mdiDelete, mdiDeleteOff, mdiPencil, mdiPencilOff },
+    toDelete: null, // We do not want to watch this object, so we use a slightly different solution,
+    shiftsToDelete: []
+  }),
+  computed: {
+    ...mapGetters({
+      shifts: "shift/shifts",
+      loading: "shift/loading",
+      selectedContract: "selectedContract",
+      shiftsOfContract: "shift/shiftsOfContract"
+    }),
+    deleteDisabled() {
+      return this.shiftsToDelete.length === 0;
+    },
+    deleteLabel() {
+      if (this.deleteDisabled) return "Delete";
+
+      const shift = this.shiftsToDelete.length > 1 ? "shifts" : "shift";
+
+      return `Delete (${this.shiftsToDelete.length} ${shift})`;
+    }
+  },
+  watch: {
+    toDelete: {
+      handler: function(value) {
+        const arr = [];
+
+        Object.entries(value).forEach(entry => {
+          const [key, indices] = entry;
+          indices.forEach(index => {
+            arr.push(this.shiftsByMonth[key][index]);
+          });
+        });
+
+        this.shiftsToDelete = arr;
+      },
+      deep: true
+    }
+  },
+  mounted() {
+    this.groupShiftsByMonth();
+    this.$store.dispatch("contract/queryContracts");
+  },
+  methods: {
+    destroy() {
+      const promises = [];
+      for (const shift of this.shiftsToDelete) {
+        promises.push(ShiftService.delete(shift.uuid).catch(handleApiError));
+      }
+
+      Promise.all(promises).finally(() => {
+        this.groupShiftsByMonth();
+        this.dialog = false;
+        this.editable = false;
+      });
+    },
+    groupShiftsByMonth() {
+      this.$store.dispatch("shift/queryShifts").then(() => {
+        this.shiftsByMonth = datesGroupByComponent(
+          this.shiftsOfContract,
+          "y MM"
+        );
+      });
+    },
+    handleSelection(key, event) {
+      // Initialize, if this is our first time
+      if (this.toDelete === null) {
+        this.toDelete = {};
+      }
+
+      this.toDelete = { ...this.toDelete, [key]: event };
+    },
+    resetSelection(key) {
+      // eslint-disable-next-line no-unused-vars
+      const { [key]: value, ...withoutRemoved } = this.toDelete;
+      this.toDelete = { ...withoutRemoved };
+    },
+    toggleEdit() {
+      this.editable = !this.editable;
+    }
+  }
 };
 </script>

--- a/src/views/ViewShiftList.vue
+++ b/src/views/ViewShiftList.vue
@@ -148,6 +148,8 @@ export default {
   watch: {
     toDelete: {
       handler: function(value) {
+        if (value === null) return;
+
         const arr = [];
 
         Object.entries(value).forEach(entry => {
@@ -177,6 +179,9 @@ export default {
         this.groupShiftsByMonth();
         this.dialog = false;
         this.editable = false;
+
+        this.shiftsToDelete = [];
+        this.toDelete = null;
       });
     },
     groupShiftsByMonth() {

--- a/tests/e2e/fixtures/shifts.json
+++ b/tests/e2e/fixtures/shifts.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "dac0ea17-e0d5-43dd-8032-bba8ac41f43c",
+    "tags": ["tag1", "tag2"],
+    "started": "2019-11-25T18:20:38+01:00",
+    "stopped": "2019-11-25T23:59:59+01:00",
+    "type": "sk",
+    "note": "",
+    "was_reviewed": true,
+    "was_exported": false,
+    "created_at": "2019-11-27T19:53:45.060876+01:00",
+    "modified_at": "2019-11-27T19:53:45.060944+01:00",
+    "contract": "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
+  },
+  {
     "id": "6e4d3cad-681c-4b3f-b328-dc49be3d6f53",
     "tags": [],
     "started": "2019-09-13T06:30:00+02:00",
@@ -39,19 +52,6 @@
     "contract": "df293949-6dba-4f1f-a10e-0bb95f1a46d7"
   },
   {
-    "id": "dac0ea17-e0d5-43dd-8032-bba8ac41f43c",
-    "tags": [],
-    "started": "2019-11-25T18:20:38+01:00",
-    "stopped": "2019-11-25T23:59:59+01:00",
-    "type": "st",
-    "note": "",
-    "was_reviewed": true,
-    "was_exported": false,
-    "created_at": "2019-11-27T19:53:45.060876+01:00",
-    "modified_at": "2019-11-27T19:53:45.060944+01:00",
-    "contract": "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
-  },
-  {
     "id": "7d08fa88-8ab3-489f-b20f-06055a1cf939",
     "tags": [],
     "started": "2019-11-27T00:00:00+01:00",
@@ -62,6 +62,32 @@
     "was_exported": false,
     "created_at": "2019-11-27T19:53:45.294094+01:00",
     "modified_at": "2019-11-27T19:53:45.294180+01:00",
+    "contract": "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
+  },
+  {
+    "id": "bc39f918-bc79-4ac9-9ebf-1bce71f98ece",
+    "tags": [],
+    "started": "2019-10-18T00:00:00+01:00",
+    "stopped": "2019-10-18T01:00:00+01:00",
+    "type": "st",
+    "note": "",
+    "was_reviewed": false,
+    "was_exported": false,
+    "created_at": "2019-10-17T22:55:30.178299+01:00",
+    "modified_at": "2019-10-17T22:55:30.178367+01:00",
+    "contract": "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
+  },
+  {
+    "id": "b8024303-4e35-4102-83d5-688370604a46",
+    "tags": [],
+    "started": "2019-10-17T01:00:00+01:00",
+    "stopped": "2019-10-17T01:00:00+01:00",
+    "type": "st",
+    "note": "",
+    "was_reviewed": true,
+    "was_exported": true,
+    "created_at": "2019-10-17T22:42:41.544529+01:00",
+    "modified_at": "2019-10-17T22:55:23.650819+01:00",
     "contract": "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
   },
   {

--- a/tests/e2e/specs/shift.spec.js
+++ b/tests/e2e/specs/shift.spec.js
@@ -241,12 +241,11 @@ describe("returns to correct previous view", () => {
     });
 
     it("redirects to shift list", () => {
-      throw new Error("not yet implemented. Requires PR #81.");
-
-      // cy.visit("http://localhost:8080/shifts");
-      // cy.get("[data-cy=shift-create-button]").click();
-      // cy.get("[data-cy=shift-save]").click();
-      // cy.url().should("contain", "/shifts");
+      cy.visit("http://localhost:8080/shifts");
+      cy.get("[data-cy=shift-create-button]").click();
+      cy.url().should("contain", "/shifts/create");
+      cy.get("[data-cy=shift-save]").click();
+      cy.url().should("contain", "/shifts");
     });
   });
 
@@ -270,13 +269,13 @@ describe("returns to correct previous view", () => {
     });
 
     it("redirects to shift list", () => {
-      throw new Error("not yet implemented. Requires PR #81.");
-
-      // cy.visit("http://localhost:8080/shifts");
-      // cy.get("tbody > :nth-child(1) > :nth-child(1)").click();
-      // cy.get("[data-cy=shift-edit]").click();
-      // cy.get("[data-cy=shift-save]").click();
-      // cy.url().should("contain", "/shifts");
+      cy.get("[data-cy=shift-list-item-2]").click();
+      cy.url().should(
+        "contain",
+        "/shifts/dac0ea17-e0d5-43dd-8032-bba8ac41f43c/edit"
+      );
+      cy.get("[data-cy=shift-save]").click();
+      cy.url().should("contain", "/shifts");
     });
   });
 });

--- a/tests/e2e/specs/shiftlist.spec.js
+++ b/tests/e2e/specs/shiftlist.spec.js
@@ -1,164 +1,282 @@
 describe("Shift list table", () => {
-  beforeEach(() => {
-    cy.server();
-    cy.route("GET", "/api/shifts/", "fixture:shifts.json");
-
-    cy.login();
-    cy.selectContract();
-
-    cy.visit("http://localhost:8080/shifts");
-  });
-
-  it("lists all shifts", () => {
-    cy.get("[data-cy=shift-table]")
-      .should("contain", "Work time sum:")
-      .should("contain", "25th November 2019")
-      .should("contain", "26th November 2019")
-      .should("contain", "27th November 2019");
-  });
-
-  context("no shift selected", () => {
-    it("shows disabled edit button", () => {
-      cy.get("[data-cy=shift-edit]").should("be.disabled");
-    });
-
-    it("shows disabled delete button", () => {
-      cy.get("[data-cy=shift-delete]").should("be.disabled");
-    });
-  });
-
-  context("one shift selected", () => {
+  context("without existing shifts", () => {
     beforeEach(() => {
-      // Select single shift
-      cy.get(
-        "tbody > :nth-child(1) > :nth-child(1) > .v-data-table__checkbox > .v-input--selection-controls__ripple"
-      ).click();
-    });
-
-    afterEach(() => {
-      // Reset selections
-      cy.get(
-        '[aria-label=""] > .v-data-table__checkbox > .v-input--selection-controls__ripple'
-      )
-        .click()
-        .click();
-    });
-
-    it("shows enabled edit button", () => {
-      cy.get("[data-cy=shift-edit]").should("not.be.disabled");
-    });
-
-    it("shows enabled delete button", () => {
-      cy.get("[data-cy=shift-delete]")
-        .should("not.be.disabled")
-        .should("contain", "Delete (1 shift)");
-    });
-
-    it("shows an error when trying to delete a stale shift", () => {
       cy.server();
-      cy.get("[data-cy=shift-delete]").click();
-      cy.get("[data-cy=delete-dialog]").should("contain", "Delete shifts?");
-      cy.get("[data-cy=delete-confirm]").click();
-      cy.get("[data-cy=delete-dialog]").should("not.be.visible");
-      cy.get("[data-cy=snackbar]").should("contain", "Not found.");
+      cy.route("GET", "/api/shifts/").as("shifts");
+
+      cy.login();
+      cy.selectContract();
+
+      cy.visit("http://localhost:8080/shifts");
+    });
+
+    it("shows a skeleton placeholder while loading and empty placeholder after loading", () => {
+      cy.get("[data-cy=shift-list-skeleton]").should("be.visible");
+      cy.wait("@shifts");
+      cy.get("[data-cy=shift-list-skeleton]").should("not.be.visible");
+      cy.get("[data-cy=shift-list-empty-placeholder]").should("be.visible");
     });
   });
 
-  context("multiple shifts selected", () => {
-    beforeEach(() => {
-      // Select two shifts
-      cy.get(
-        "tbody > :nth-child(1) > :nth-child(1) > .v-data-table__checkbox > .v-input--selection-controls__ripple"
-      ).click();
-      cy.get(
-        ":nth-child(3) > :nth-child(1) > .v-data-table__checkbox > .v-input--selection-controls__ripple"
-      ).click();
+  context.only("with existing shifts", () => {
+    before(() => {
+      cy.server();
+      cy.route("GET", "/api/shifts/", "fixture:shifts.json").as("shifts");
+
+      cy.login();
+      cy.selectContract();
+
+      cy.visit("http://localhost:8080/shifts");
+      cy.wait("@shifts");
     });
 
-    afterEach(() => {
-      // Reset selections
+    it("shows shifts in a list", () => {
+      cy.get("[data-cy=shift-lists]");
+    });
+
+    it("separates each month into a separate list", () => {
+      cy.get('[data-cy="shift-list-2019 11"]');
+      cy.get('[data-cy="shift-list-2019 10"]');
+    });
+
+    it("shows a header with the month name and total sum", () => {
       cy.get(
-        '[aria-label=""] > .v-data-table__checkbox > .v-input--selection-controls__ripple'
+        '[data-cy="shift-list-2019 11"] > .v-subheader > [data-cy=shift-list-header]'
       )
-        .click()
-        .click();
+        .should("contain", "November 2019")
+        .should("contain", "Work time sum: 29:32 / 20:00");
+
+      cy.get(
+        '[data-cy="shift-list-2019 10"] > .v-subheader > [data-cy=shift-list-header]'
+      )
+        .should("contain", "October 2019")
+        .should("contain", "Work time sum: 01:00 / 20:00");
     });
 
-    it("shows disabled edit button", () => {
-      cy.get("[data-cy=shift-edit]").should("be.disabled");
+    it("shows a single list item per shift", () => {
+      cy.get('[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group]')
+        .children()
+        .should("have.length", 3);
+
+      cy.get('[data-cy="shift-list-2019 10"] > [data-cy=shift-list-group]')
+        .children()
+        .should("have.length", 2);
     });
 
-    it("shows enabled delete button", () => {
-      cy.get("[data-cy=shift-delete]")
-        .should("not.be.disabled")
-        .should("contain", "Delete (2 shifts)");
+    it("shows information for every shift", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-0] > .v-list-item__content'
+      )
+        .should("contain", "Wednesday, 27th")
+        .should("contain", "00:00 - 19:53 (19h 53m)");
     });
 
-    it("shows a dismissable dialog to confirm deletion", () => {
-      cy.get("[data-cy=shift-delete]").click();
-      cy.get("[data-cy=delete-dialog]").should("contain", "Delete shifts?");
+    it("shows a type for every shift", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-0] > .v-list-item__content > :nth-child(3) > [data-cy=shift-list-item-type]'
+      ).should("contain", "Shift");
+      cy.get(
+        "[data-cy=shift-list-item-2] > .v-list-item__content > :nth-child(3) > [data-cy=shift-list-item-type]"
+      ).should("contain", "Sick");
+    });
+
+    it("shows tags for every shift, if available", () => {
+      cy.get(
+        "[data-cy=shift-list-item-0] > .v-list-item__content > :nth-child(3) > [data-cy=shift-list-item-tag-0]"
+      ).should("not.be.visible");
+
+      cy.get(
+        "[data-cy=shift-list-item-2] > .v-list-item__content > :nth-child(3) > [data-cy=shift-list-item-tag-0]"
+      ).should("be.visible");
+      cy.get(
+        "[data-cy=shift-list-item-2] > .v-list-item__content > :nth-child(3)  > [data-cy=shift-list-item-tag-1]"
+      ).should("be.visible");
+    });
+
+    it("sorts shift by start date in descending order", () => {
+      cy.get('[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group]')
+        .find(".v-list-item__content")
+        .as("novemberShifts");
+
+      cy.get("@novemberShifts")
+        .eq(0)
+        .should("contain", "Wednesday, 27th");
+      cy.get("@novemberShifts")
+        .eq(1)
+        .should("contain", "Tuesday, 26th");
+      cy.get("@novemberShifts")
+        .eq(2)
+        .should("contain", "Monday, 25th");
+    });
+
+    it("shows the edit mode button", () => {
+      cy.get("[data-cy=shift-list-delete-button]").should("not.be.visible");
+      cy.get("[data-cy=shift-list-edit-mode-button]");
+    });
+
+    it("enabled edit mode when clicking the button", () => {
+      cy.get("[data-cy=shift-list-edit-mode-button]").click();
+      cy.get("[data-cy=shift-list-delete-button]").should("be.visible");
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete")
+        .should("have.attr", "disabled");
+    });
+
+    it("shows unticked checkboxes in when in edit mode", () => {
+      cy.get('[data-cy="shift-list-toggle-all"]').should("have.length", 2);
+      cy.get('[data-cy="shift-lists"]')
+        .find("input")
+        .should("have.length", 7)
+        .each($el => {
+          cy.wrap($el).should("have.attr", "value", "false");
+        });
+    });
+
+    it("toggles all shifts when clicking the checkbox", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 11"] > .v-subheader > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+      ).click();
+
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (3 shifts)")
+        .should("not.have.attr", "disabled");
+    });
+
+    it("untoggles shifts when clicking checkbox separately", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-1] > .v-list-item__action > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+      ).click();
+
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (2 shifts)")
+        .should("not.have.attr", "disabled");
+    });
+
+    it("untoggles shifts when clicking shift item separately", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-0]'
+      ).click();
+
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (1 shift)")
+        .should("not.have.attr", "disabled");
+    });
+
+    it("can toggle and combine with different month", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 10"] > .v-subheader > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+      ).click();
+
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (3 shifts)")
+        .should("not.have.attr", "disabled");
+    });
+
+    it("will first select all remaining, then deselect all on click", () => {
+      cy.get('[data-cy="shift-list-2019 10"] > [data-cy=shift-list-group]')
+        .find("input")
+        .as("checkboxes");
+
+      cy.get(
+        '[data-cy="shift-list-2019 10"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-1] > .v-list-item__action > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+      ).click();
+      cy.get("@checkboxes")
+        .first()
+        .should("have.attr", "value", "true");
+      cy.get("@checkboxes")
+        .last()
+        .should("have.attr", "value", "false");
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (2 shifts)")
+        .should("not.have.attr", "disabled");
+
+      cy.get(
+        '[data-cy="shift-list-2019 10"] > .v-subheader > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+      ).click();
+      cy.get("@checkboxes")
+        .first()
+        .should("have.attr", "value", "true");
+      cy.get("@checkboxes")
+        .last()
+        .should("have.attr", "value", "true");
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (3 shifts)")
+        .should("not.have.attr", "disabled");
+
+      cy.get(
+        '[data-cy="shift-list-2019 10"] > .v-subheader > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+      ).click();
+      cy.get("@checkboxes")
+        .first()
+        .should("have.attr", "value", "false");
+      cy.get("@checkboxes")
+        .last()
+        .should("have.attr", "value", "false");
+      cy.get("[data-cy=shift-list-delete-button]")
+        .should("contain", "Delete (1 shift)")
+        .should("not.have.attr", "disabled");
+    });
+
+    it("shows a confirm dialog when trying to delete", () => {
+      cy.get("[data-cy=shift-list-delete-button]").click();
+      cy.get("[data-cy=delete-dialog]", { timeout: 1000 }).should(
+        "contain",
+        "Are you sure you want to delete the selected shifts? This action is permanent."
+      );
+      cy.get("[data-cy=delete-dialog]").should("be.visible");
+    });
+
+    it("can cancel the delete dialog", () => {
       cy.get("[data-cy=delete-cancel]").click();
       cy.get("[data-cy=delete-dialog]").should("not.be.visible");
     });
 
-    it("deletes selected shifts on confirm", () => {
-      cy.server();
-      cy.route({ method: "DELETE", url: "**/shifts/*", response: {} });
-
-      cy.route("GET", "/api/shifts/", [
-        {
-          id: "01c7098c-c209-4e61-86b2-da4652163ed9",
-          tags: [],
-          started: "2019-11-26T12:00:00+01:00",
-          stopped: "2019-11-26T16:00:00+01:00",
-          type: "st",
-          note: "",
-          was_reviewed: true,
-          was_exported: false,
-          created_at: "2019-11-27T19:53:45.394670+01:00",
-          modified_at: "2019-11-27T19:53:45.394725+01:00",
-          contract: "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
-        }
-      ]);
-
-      cy.get("[data-cy=shift-delete]").click();
-      cy.get("[data-cy=delete-dialog]").should("contain", "Delete shifts?");
-      cy.get("[data-cy=delete-confirm]").click();
+    it("can cancel the delete dialog with escape key", () => {
+      cy.get("[data-cy=shift-list-delete-button]").click();
+      cy.focused().type("{esc}");
       cy.get("[data-cy=delete-dialog]").should("not.be.visible");
-
-      cy.get("[data-cy=shift-table]")
-        .should("not.contain", "25th November 2019")
-        .should("contain", "26th November 2019")
-        .should("not.contain", "27th November 2019");
-    });
-  });
-
-  context("edit one shift", () => {
-    beforeEach(() => {
-      // Select single shift
-      cy.get(
-        "tbody > :nth-child(1) > :nth-child(1) > .v-data-table__checkbox > .v-input--selection-controls__ripple"
-      ).click();
     });
 
-    it("redirects to shift form", () => {
+    it("can delete a shift", () => {
       cy.server();
-      cy.route("GET", "/api/shifts/7d08fa88-8ab3-489f-b20f-06055a1cf939", {
-        id: "7d08fa88-8ab3-489f-b20f-06055a1cf939",
-        tags: [],
-        started: "2019-11-27T00:00:00+01:00",
-        stopped: "2019-11-27T19:53:06+01:00",
-        type: "st",
-        note: "",
-        was_reviewed: true,
-        was_exported: false,
-        created_at: "2019-11-27T19:53:45.294094+01:00",
-        modified_at: "2019-11-27T19:53:45.294180+01:00",
-        contract: "178bc9a6-132e-46ab-8fa2-df8e22c229b6"
+      cy.route("GET", "/api/shifts/", "fixture:shifts.json").as("shifts");
+
+      cy.login();
+      cy.selectContract();
+
+      cy.visit("http://localhost:8080/shifts");
+
+      cy.fixture("shifts.json").then(shifts => {
+        cy.wait("@shifts");
+
+        const remainingShifts = shifts.slice(1);
+        cy.route("GET", "/api/shifts/", remainingShifts);
+        cy.route("DELETE", "/api/shifts/**", {});
+
+        cy.get("[data-cy=shift-list-edit-mode-button]").click();
+        cy.get(
+          '[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-0] > .v-list-item__action > .v-input > .v-input__control > .v-input__slot > .v-input--selection-controls__input > .v-input--selection-controls__ripple'
+        ).click();
+
+        cy.get("[data-cy=shift-list-delete-button]").click();
+        cy.get("[data-cy=delete-confirm]").click();
+        cy.get("[data-cy=delete-dialog]").should("not.be.visible");
+
+        cy.get('[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group]')
+          .children()
+          .should("have.length", 2);
+
+        cy.get('[data-cy="shift-list-2019 10"] > [data-cy=shift-list-group]')
+          .children()
+          .should("have.length", 2);
+        cy.get("[data-cy=shift-list-delete-button]").should("not.be.visible");
       });
+    });
 
-      cy.get("[data-cy=shift-edit]").click();
-
+    it("redirects to shift form when clicking a shift list item", () => {
+      cy.get(
+        '[data-cy="shift-list-2019 11"] > [data-cy=shift-list-group] > [data-cy=shift-list-item-0] > .v-list-item__content'
+      ).click();
       cy.url().should("contain", "7d08fa88-8ab3-489f-b20f-06055a1cf939/edit");
     });
   });

--- a/tests/e2e/specs/shiftlist.spec.js
+++ b/tests/e2e/specs/shiftlist.spec.js
@@ -18,7 +18,7 @@ describe("Shift list table", () => {
     });
   });
 
-  context.only("with existing shifts", () => {
+  context("with existing shifts", () => {
     before(() => {
       cy.server();
       cy.route("GET", "/api/shifts/", "fixture:shifts.json").as("shifts");

--- a/yarn.lock
+++ b/yarn.lock
@@ -11374,6 +11374,11 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue-undraw@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/vue-undraw/-/vue-undraw-2.0.13.tgz#3726e3ca3b87939ded89e50d54d90db23f247776"
+  integrity sha512-GcvwxKIc0aZuXsuUo5VJgCEcXz68B1fCRlTSPYyLgwTzRDJ8rZy1aLMQYbKJoBFAdVvfsYYq9tqp3/MYVopUvw==
+
 vue@2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"


### PR DESCRIPTION
- New components! We now use v-list instead of v-data-table.
- Added undraw placeholder if we have no shifts.
- Months are shown seperately in own lists.
- Work time is now shown per month.
- Can delete from all months at the same time.
- New getters.

Resolves #54.
Resolves #55.
Resolves #57.

### To-Do

- [x] Add shift type to list (#56)
- [x] Sortierung der Schichten Konsistent halten.
  - [x] Innerhalb eines Monats den jüngsten Tag oben.
  - [ ] Jüngster Monat oben, ältester Monat unten.
- [x] Tests
- [x] Update failing tests that were added in #82