### PR TITLE
Refactor ShiftForm

### DIFF
--- a/src/components/TheFAB.vue
+++ b/src/components/TheFAB.vue
@@ -12,6 +12,7 @@
       color="purple lighten-2"
       data-cy="shift-create-button"
       :to="to"
+      @click="click"
     >
       <v-icon>{{ icons.mdiPlus }}</v-icon>
     </v-btn>
@@ -26,7 +27,11 @@ export default {
   props: {
     to: {
       type: Object,
-      required: true
+      default: () => {}
+    },
+    click: {
+      type: Function,
+      default: () => {}
     }
   },
   data: () => ({

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -72,12 +72,9 @@
             <v-btn
               text
               color="primary"
-              :to="{
-                name: 'editShift',
-                params: { uuid: selectedEvent.uuid }
-              }"
               :disabled="selectedEvent.exported"
               data-cy="calendar-selected-event-edit"
+              @click="editShift(selectedEvent.uuid)"
             >
               Edit
             </v-btn>
@@ -125,7 +122,15 @@
         </template>
       </TheDialog>
 
-      <TheFAB :to="{ name: 'createShift' }" />
+      <ShiftFormDialog
+        v-if="shiftEntity !== null"
+        :shift-entity="shiftEntity"
+        :now="new Date(focus)"
+        @close="shiftEntity = null"
+        @refresh="$emit('refresh')"
+      />
+
+      <TheFAB :to="null" :click="newShift" />
     </v-sheet>
   </div>
 </template>
@@ -137,6 +142,7 @@ import { Contract } from "@/models/ContractModel";
 import ShiftService from "@/services/shift";
 import { handleApiError } from "@/utils/interceptors";
 
+import ShiftFormDialog from "@/components/shifts/ShiftFormDialog";
 import CalendarNavigationButtons from "@/components/calendar/CalendarNavigationButtons";
 import CalendarTypeSelect from "@/components/calendar/CalendarTypeSelect";
 import TheDialog from "@/components/TheDialog";
@@ -151,6 +157,7 @@ export default {
   components: {
     CalendarNavigationButtons,
     CalendarTypeSelect,
+    ShiftFormDialog,
     TheDialog,
     TheFAB
   },
@@ -191,7 +198,8 @@ export default {
     weekdays: [1, 2, 3, 4, 5, 6, 0],
     eventClicks: 0,
     doubleClickTimer: null,
-    doubleClickDelay: 500
+    doubleClickDelay: 500,
+    shiftEntity: null
   }),
   computed: {
     visibleShifts() {
@@ -270,6 +278,13 @@ export default {
     this.$refs.calendar.checkChange();
   },
   methods: {
+    editShift(uuid) {
+      const shift = this.visibleShifts.find(shift => shift.uuid === uuid);
+      this.shiftEntity = new Shift(shift);
+    },
+    newShift() {
+      this.shiftEntity = new Shift();
+    },
     handleEventClick({ nativeEvent, event }) {
       this.eventClicks++;
       this.showEvent({ nativeEvent, event });

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -125,7 +125,7 @@
       <ShiftFormDialog
         v-if="shiftEntity !== null"
         :shift-entity="shiftEntity"
-        :now="new Date(focus)"
+        :now="shiftNow"
         @close="shiftEntity = null"
         @refresh="$emit('refresh')"
       />
@@ -202,6 +202,12 @@ export default {
     shiftEntity: null
   }),
   computed: {
+    shiftNow() {
+      const now = new Date();
+      const [year, month, day] = this.focus.split("-");
+
+      return new Date(year, month, day, now.getHours(), now.getMinutes());
+    },
     visibleShifts() {
       return this.shifts.filter(
         shift => shift.contract === this.$store.state.selectedContract.uuid

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -20,7 +20,7 @@
     </v-overlay>
 
     <v-row align="center" justify="start">
-      <v-col cols="5">
+      <v-col cols="12" md="5">
         <ShiftFormDateInput
           v-model="shift"
           data-cy="shift-date"
@@ -30,13 +30,14 @@
         />
       </v-col>
 
-      <v-col cols="3">
+      <v-col cols="6" md="3">
         <ShiftFormTimeInput
           v-model="shift"
           data-cy="shift-start-time"
           :errors="startTimeErrors"
           label="Start"
           type="start"
+          :prepend-icon="$vuetify.breakpoint.smAndDown"
           @update="$v.shift.date.start.$touch() || $v.shift.date.end.$touch()"
         />
       </v-col>
@@ -45,7 +46,7 @@
         to
       </v-col>
 
-      <v-col cols="3">
+      <v-col cols="5" md="3">
         <ShiftFormTimeInput
           v-model="shift"
           data-cy="shift-end-time"

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -19,8 +19,8 @@
       </v-card>
     </v-overlay>
 
-    <v-row align="center" justify="center">
-      <v-col cols="5" md="4">
+    <v-row align="center" justify="start">
+      <v-col cols="5">
         <ShiftFormDateInput
           v-model="shift"
           data-cy="shift-date"
@@ -30,7 +30,7 @@
         />
       </v-col>
 
-      <v-col cols="3" md="2">
+      <v-col cols="3">
         <ShiftFormTimeInput
           v-model="shift"
           data-cy="shift-start-time"
@@ -45,7 +45,7 @@
         to
       </v-col>
 
-      <v-col cols="3" md="2">
+      <v-col cols="3">
         <ShiftFormTimeInput
           v-model="shift"
           data-cy="shift-end-time"
@@ -56,32 +56,28 @@
         />
       </v-col>
 
-      <v-col cols="12" md="10">
+      <v-col cols="12">
         <ShiftFormTags v-model="shift.tags" data-cy="shift-tags" />
         <ShiftFormInput v-model="shift.note" data-cy="shift-note" />
         <ShiftFormType v-model="shift.type" data-cy="shift-type" />
       </v-col>
 
-      <v-col cols="12" md="10">
-        <v-expansion-panels :elevation="0">
-          <v-expansion-panel>
-            <v-expansion-panel-header
-              >Advanced settings</v-expansion-panel-header
-            >
-            <v-expansion-panel-content>
-              <v-subheader>Change contract</v-subheader>
+      <v-col cols="12">
+        <v-divider></v-divider>
+      </v-col>
 
-              <v-select
-                v-model="shift.contract"
-                data-cy="shift-contract"
-                :items="contracts"
-                item-text="name"
-                item-value="uuid"
-                outlined
-              ></v-select>
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
+      <v-col cols="12" class="pb-0">
+        <v-subheader>Advanced settings</v-subheader>
+        <v-select
+          v-model="shift.contract"
+          data-cy="shift-contract"
+          :items="contracts"
+          :prepend-icon="icons.mdiFileDocumentEditOutline"
+          label="Change contract"
+          item-text="name"
+          item-value="uuid"
+          filled
+        ></v-select>
       </v-col>
     </v-row>
   </v-form>
@@ -107,6 +103,8 @@ import { required } from "vuelidate/lib/validators";
 
 const startBeforeEnd = (value, vm) => isBefore(value, vm.end);
 const endAfterStart = (value, vm) => isAfter(value, vm.start);
+
+import { mdiFileDocumentEditOutline } from "@mdi/js";
 
 export default {
   name: "ShiftForm",
@@ -149,6 +147,7 @@ export default {
     }
   },
   data: () => ({
+    icons: { mdiFileDocumentEditOutline },
     dialog: false,
     select: null,
     shift: null

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -57,9 +57,9 @@
       </v-col>
 
       <v-col cols="12" md="10">
-        <ShiftFormSelect v-model="shift.type" data-cy="shift-type" />
         <ShiftFormTags v-model="shift.tags" data-cy="shift-tags" />
         <ShiftFormInput v-model="shift.note" data-cy="shift-note" />
+        <ShiftFormType v-model="shift.type" data-cy="shift-type" />
       </v-col>
 
       <v-col cols="12" md="10">
@@ -90,7 +90,7 @@
 <script>
 import ShiftFormDateInput from "@/components/shifts/ShiftFormDateInput";
 import ShiftFormTimeInput from "@/components/shifts/ShiftFormTimeInput";
-import ShiftFormSelect from "@/components/shifts/ShiftFormSelect";
+import ShiftFormType from "@/components/shifts/ShiftFormType";
 import ShiftFormInput from "@/components/shifts/ShiftFormInput";
 import ShiftFormTags from "@/components/shifts/ShiftFormTags";
 
@@ -114,7 +114,7 @@ export default {
     ShiftFormDateInput,
     ShiftFormTimeInput,
     ShiftFormInput,
-    ShiftFormSelect,
+    ShiftFormType,
     ShiftFormTags
   },
   filters: {

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -188,7 +188,7 @@ import ShiftService from "@/services/shift";
 import { Shift } from "@/models/ShiftModel";
 import { Contract } from "@/models/ContractModel";
 
-import { mapState } from "vuex";
+import { mapGetters } from "vuex";
 import { format, isAfter, isBefore } from "date-fns";
 
 import { startEndHours } from "@/utils/time";
@@ -247,32 +247,15 @@ export default {
   data: () => ({
     dialog: false,
     select: null,
-    shift: null,
-    stepper: 1,
-    stepperText: [
-      {
-        title: "Time and date",
-        subtitle: "Choose the date and start/end times of your shift."
-      },
-      {
-        title: "Set the hours per month",
-        subtitle: "Your montly worktime (HH:mm)."
-      },
-      {
-        title: "Summary",
-        subtitle: " "
-      }
-    ]
+    shift: null
   }),
   computed: {
-    ...mapState("contract", {
-      contracts: state => state.contracts
+    ...mapGetters({
+      contracts: "contract/contracts",
+      selectedContract: "selectedContract"
     }),
     shiftExported() {
       return this.shift.exported;
-    },
-    currentText() {
-      return this.stepperText[this.stepper - 1];
     },
     tags() {
       return this.shift.tags.join(", ");
@@ -339,7 +322,7 @@ export default {
     this.shift = this.uuid === null ? this.initialData : this.entity;
 
     if (!this.shift.contract) {
-      this.shift.contract = this.$store.state.selectedContract.uuid;
+      this.shift.contract = this.selectedContract.uuid;
     }
   },
   methods: {
@@ -381,12 +364,6 @@ export default {
       const [year, month, day] = contractStart.split("-");
       this.shift.setDate(...[year, month - 1, day], "start");
       this.shift.setDate(...[year, month - 1, day], "end");
-    },
-    nextStep() {
-      this.stepper += 1;
-    },
-    previousStep() {
-      this.stepper -= 1;
     },
     async submit(callback, shift) {
       callback(shift)

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -60,6 +60,10 @@
       <v-col cols="12">
         <ShiftFormTags v-model="shift.tags" data-cy="shift-tags" />
         <ShiftFormInput v-model="shift.note" data-cy="shift-note" />
+
+        <v-subheader class="pl-8" style="height: 10px">
+          What category does this shift fall into?
+        </v-subheader>
         <ShiftFormType v-model="shift.type" data-cy="shift-type" />
       </v-col>
 
@@ -68,7 +72,7 @@
       </v-col>
 
       <v-col cols="12" class="pb-0">
-        <v-subheader>Advanced settings</v-subheader>
+        <v-subheader class="pl-8">Advanced settings</v-subheader>
         <v-select
           v-model="shift.contract"
           data-cy="shift-contract"

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -245,6 +245,10 @@ export default {
       const contractEnd = this.contract.date.end;
       const now = this.now;
 
+      // If we go to fast, contractStart is null and we get an error.
+      // Gotta go fast.
+      if (contractStart === null || contractEnd === null) return;
+
       // Do nothing if current date is inside the
       // selected contract
       if (

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -19,79 +19,51 @@
       </v-card>
     </v-overlay>
 
-    <v-row>
-      <v-col>
-        <h1>{{ title }}</h1>
-      </v-col>
-    </v-row>
-
-    <v-row dense>
-      <v-col sm="12">
-        <v-card min-width="330">
-          <v-row>
-            <v-col cols="12" sm="12" md="7">
-              <v-subheader>Select shift date</v-subheader>
-              <v-card-text class="pt-0">
-                <v-row justify="center">
-                  <ShiftFormDateInlineInput
-                    v-model="shift"
-                    data-cy="shift-date"
-                    :min="contract.date.start"
-                    :max="contract.date.end"
-                  />
-                </v-row>
-              </v-card-text>
-            </v-col>
-            <v-col cols="12" sm="12" md="5">
-              <v-subheader
-                >What time did you start and end your shift?</v-subheader
-              >
-              <v-card-text>
-                <ShiftFormTimeInput
-                  v-model="shift"
-                  data-cy="shift-start-time"
-                  :errors="startTimeErrors"
-                  label="Start time"
-                  type="start"
-                  @update="
-                    $v.shift.date.start.$touch() || $v.shift.date.end.$touch()
-                  "
-                />
-              </v-card-text>
-              <v-card-text>
-                <ShiftFormTimeInput
-                  v-model="shift"
-                  data-cy="shift-end-time"
-                  :errors="endTimeErrors"
-                  label="End time"
-                  type="end"
-                  @update="
-                    $v.shift.date.end.$touch() || $v.shift.date.start.$touch()
-                  "
-                />
-              </v-card-text>
-            </v-col>
-          </v-row>
-        </v-card>
+    <v-row align="center" justify="center">
+      <v-col cols="5" md="4">
+        <ShiftFormDateInput
+          v-model="shift"
+          data-cy="shift-date"
+          :min="contract.date.start"
+          :max="contract.date.end"
+          label="Date"
+        />
       </v-col>
 
-      <v-col cols="12" sm="12">
-        <v-card>
-          <v-row>
-            <v-col>
-              <v-subheader>Additional information</v-subheader>
-              <v-card-text>
-                <ShiftFormSelect v-model="shift.type" data-cy="shift-type" />
-                <ShiftFormTags v-model="shift.tags" data-cy="shift-tags" />
-                <ShiftFormInput v-model="shift.note" data-cy="shift-note" />
-              </v-card-text>
-            </v-col>
-          </v-row>
-        </v-card>
+      <v-col cols="3" md="2">
+        <ShiftFormTimeInput
+          v-model="shift"
+          data-cy="shift-start-time"
+          :errors="startTimeErrors"
+          label="Start"
+          type="start"
+          @update="$v.shift.date.start.$touch() || $v.shift.date.end.$touch()"
+        />
       </v-col>
 
-      <v-col cols="12" sm="12">
-        <v-expansion-panels>
+      <v-col cols="1" class="px-0 text-center">
+        to
+      </v-col>
+
+      <v-col cols="3" md="2">
+        <ShiftFormTimeInput
+          v-model="shift"
+          data-cy="shift-end-time"
+          :errors="endTimeErrors"
+          label="End"
+          type="end"
+          @update="$v.shift.date.end.$touch() || $v.shift.date.start.$touch()"
+        />
+      </v-col>
+
+      <v-col cols="12" md="10">
+        <ShiftFormSelect v-model="shift.type" data-cy="shift-type" />
+        <ShiftFormTags v-model="shift.tags" data-cy="shift-tags" />
+        <ShiftFormInput v-model="shift.note" data-cy="shift-note" />
+      </v-col>
+
+      <v-col cols="12" md="10">
+        <v-expansion-panels :elevation="0">
           <v-expansion-panel>
             <v-expansion-panel-header
               >Advanced settings</v-expansion-panel-header
@@ -111,79 +83,16 @@
           </v-expansion-panel>
         </v-expansion-panels>
       </v-col>
-      <v-col>
-        <v-card>
-          <v-card-actions>
-            <v-btn
-              data-cy="shift-save"
-              text
-              :disabled="!valid"
-              color="primary"
-              @click="submit(query, shift)"
-              >{{ saveLabel }}</v-btn
-            >
-            <v-btn data-cy="shift-cancel" text @click="$emit('cancel')"
-              >Cancel</v-btn
-            >
-            <v-spacer></v-spacer>
-
-            <v-dialog v-model="dialog" max-width="500px">
-              <template v-slot:activator="{ on }">
-                <v-slide-x-transition>
-                  <v-btn
-                    v-if="uuid !== null"
-                    data-cy="shift-form-delete-button"
-                    text
-                    :disabled="deleteDisabled"
-                    color="error"
-                    v-on="on"
-                  >
-                    Delete
-                  </v-btn>
-                </v-slide-x-transition>
-              </template>
-
-              <v-card data-cy="delete-dialog">
-                <v-card-title>
-                  <span class="headline">Delete shifts?</span>
-                </v-card-title>
-
-                <v-card-text>
-                  Are you sure you want to delete the selected shifts? This
-                  action is permanent.
-                </v-card-text>
-
-                <v-card-actions>
-                  <v-spacer></v-spacer>
-                  <v-btn
-                    data-cy="delete-confirm"
-                    color="error"
-                    text
-                    @click="destroy"
-                  >
-                    Delete
-                  </v-btn>
-                  <v-btn data-cy="delete-cancel" text @click="dialog = false">
-                    Cancel
-                  </v-btn>
-                </v-card-actions>
-              </v-card>
-            </v-dialog>
-          </v-card-actions>
-        </v-card>
-      </v-col>
     </v-row>
   </v-form>
 </template>
 
 <script>
-import ShiftFormDateInlineInput from "@/components/shifts/ShiftFormDateInlineInput";
+import ShiftFormDateInput from "@/components/shifts/ShiftFormDateInput";
 import ShiftFormTimeInput from "@/components/shifts/ShiftFormTimeInput";
 import ShiftFormSelect from "@/components/shifts/ShiftFormSelect";
 import ShiftFormInput from "@/components/shifts/ShiftFormInput";
 import ShiftFormTags from "@/components/shifts/ShiftFormTags";
-
-import ShiftService from "@/services/shift";
 
 import { Shift } from "@/models/ShiftModel";
 import { Contract } from "@/models/ContractModel";
@@ -195,7 +104,6 @@ import { startEndHours } from "@/utils/time";
 
 import { validationMixin } from "vuelidate";
 import { required } from "vuelidate/lib/validators";
-import { handleApiError } from "@/utils/interceptors";
 
 const startBeforeEnd = (value, vm) => isBefore(value, vm.end);
 const endAfterStart = (value, vm) => isAfter(value, vm.start);
@@ -203,7 +111,7 @@ const endAfterStart = (value, vm) => isAfter(value, vm.start);
 export default {
   name: "ShiftForm",
   components: {
-    ShiftFormDateInlineInput,
+    ShiftFormDateInput,
     ShiftFormTimeInput,
     ShiftFormInput,
     ShiftFormSelect,
@@ -238,10 +146,6 @@ export default {
     entity: {
       type: Object,
       default: null
-    },
-    query: {
-      type: Function,
-      required: true
     }
   },
   data: () => ({
@@ -316,6 +220,12 @@ export default {
   watch: {
     "shift.contract": function() {
       this.setStartDate();
+    },
+    shift: {
+      handler: function() {
+        this.$emit("update", { shift: this.shift, valid: this.valid });
+      },
+      deep: true
     }
   },
   created() {
@@ -326,17 +236,6 @@ export default {
     }
   },
   methods: {
-    destroy() {
-      ShiftService.delete(this.uuid)
-        .then(() => {
-          this.$store.dispatch("shift/queryShifts");
-        })
-        .catch(handleApiError)
-        .finally(() => {
-          this.dialog = false;
-          this.$emit("redirect");
-        });
-    },
     setStartDate() {
       const contractStart = this.contract.date.start;
       const contractEnd = this.contract.date.end;
@@ -364,11 +263,6 @@ export default {
       const [year, month, day] = contractStart.split("-");
       this.shift.setDate(...[year, month - 1, day], "start");
       this.shift.setDate(...[year, month - 1, day], "end");
-    },
-    async submit(callback, shift) {
-      callback(shift)
-        .then(() => this.$emit("submit"))
-        .catch(handleApiError);
     }
   }
 };

--- a/src/components/shifts/ShiftFormDateInput.vue
+++ b/src/components/shifts/ShiftFormDateInput.vue
@@ -8,7 +8,7 @@
   >
     <template v-slot:activator="{ on }">
       <v-text-field
-        v-model="date"
+        :value="formattedDate"
         readonly
         filled
         dense
@@ -60,6 +60,9 @@ export default {
     menu: false
   }),
   computed: {
+    formattedDate() {
+      return format(this.value.date.start, "eee dd',' yyyy");
+    },
     date: {
       get() {
         return format(this.value.date.start, "yyyy-MM-dd");

--- a/src/components/shifts/ShiftFormDateInput.vue
+++ b/src/components/shifts/ShiftFormDateInput.vue
@@ -10,7 +10,10 @@
       <v-text-field
         v-model="date"
         readonly
-        prepend-inner-icon="calendar_today"
+        filled
+        dense
+        hide-details
+        :prepend-icon="icons.mdiCalendar"
         v-on="on"
       ></v-text-field>
     </template>
@@ -28,6 +31,8 @@
 import { format } from "date-fns";
 import { Shift } from "@/models/ShiftModel";
 
+import { mdiCalendar } from "@mdi/js";
+
 export default {
   name: "ShiftFormDateInput",
   props: {
@@ -42,9 +47,16 @@ export default {
     max: {
       type: String,
       default: ""
+    },
+    label: {
+      type: String,
+      default: ""
     }
   },
   data: () => ({
+    icons: {
+      mdiCalendar
+    },
     menu: false
   }),
   computed: {

--- a/src/components/shifts/ShiftFormDialog.vue
+++ b/src/components/shifts/ShiftFormDialog.vue
@@ -17,7 +17,11 @@
         <v-toolbar-title>Update shift</v-toolbar-title>
         <v-spacer v-if="$vuetify.breakpoint.smAndDown"></v-spacer>
         <v-toolbar-items v-if="$vuetify.breakpoint.smAndDown">
-          <v-btn icon @click="confirmDialog = true">
+          <v-btn
+            v-if="shiftEntity.uuid !== null"
+            icon
+            @click="confirmDialog = true"
+          >
             <v-icon>{{ icons.mdiDelete }}</v-icon>
           </v-btn>
           <v-btn text @click="save">Save</v-btn>
@@ -90,7 +94,7 @@
 <script>
 import ShiftService from "@/services/shift";
 import ShiftForm from "@/components/shifts/ShiftForm";
-// import { handleApiError } from "@/utils/interceptors";
+import { handleApiError } from "@/utils/interceptors";
 
 import { mdiDelete, mdiClose } from "@mdi/js";
 
@@ -134,6 +138,7 @@ export default {
         .then(() => {
           this.$emit("refresh");
         })
+        .catch(handleApiError)
         .finally(() => {
           this.closeMainDialog();
         });
@@ -143,6 +148,7 @@ export default {
         .then(() => {
           this.$emit("refresh");
         })
+        .catch(handleApiError)
         .finally(() => {
           this.closeMainDialog();
         });
@@ -152,6 +158,7 @@ export default {
         .then(() => {
           this.$emit("refresh");
         })
+        .catch(handleApiError)
         .finally(() => {
           this.closeMainDialog();
         });

--- a/src/components/shifts/ShiftFormDialog.vue
+++ b/src/components/shifts/ShiftFormDialog.vue
@@ -14,7 +14,9 @@
         >
           <v-icon>{{ icons.mdiClose }}</v-icon>
         </v-btn>
-        <v-toolbar-title>Update shift</v-toolbar-title>
+        <v-toolbar-title>
+          {{ shiftEntity.uuid !== null ? "Update shift" : "Create shift" }}
+        </v-toolbar-title>
         <v-spacer v-if="$vuetify.breakpoint.smAndDown"></v-spacer>
         <v-toolbar-items v-if="$vuetify.breakpoint.smAndDown">
           <v-btn

--- a/src/components/shifts/ShiftFormDialog.vue
+++ b/src/components/shifts/ShiftFormDialog.vue
@@ -30,7 +30,7 @@
         </v-toolbar-items>
       </v-toolbar>
 
-      <v-card-text>
+      <v-card-text class="pb-0">
         <ShiftForm
           :entity="shiftEntity"
           :uuid="shiftEntity.uuid"

--- a/src/components/shifts/ShiftFormDialog.vue
+++ b/src/components/shifts/ShiftFormDialog.vue
@@ -1,0 +1,161 @@
+<template>
+  <v-dialog
+    v-model="mainDialog"
+    :fullscreen="$vuetify.breakpoint.smAndDown"
+    max-width="600"
+    @click:outside="closeMainDialog"
+  >
+    <v-card>
+      <v-toolbar flat>
+        <v-btn
+          v-if="$vuetify.breakpoint.smAndDown"
+          icon
+          @click="closeMainDialog"
+        >
+          <v-icon>{{ icons.mdiClose }}</v-icon>
+        </v-btn>
+        <v-toolbar-title>Update shift</v-toolbar-title>
+        <v-spacer v-if="$vuetify.breakpoint.smAndDown"></v-spacer>
+        <v-toolbar-items v-if="$vuetify.breakpoint.smAndDown">
+          <v-btn icon @click="confirmDialog = true">
+            <v-icon>{{ icons.mdiDelete }}</v-icon>
+          </v-btn>
+          <v-btn text @click="save">Save</v-btn>
+        </v-toolbar-items>
+      </v-toolbar>
+
+      <v-card-text>
+        <ShiftForm
+          :entity="shiftEntity"
+          :uuid="shiftEntity.uuid"
+          :now="now"
+          @cancel="closeMainDialog"
+          @destroy="destroy"
+          @save="save"
+          @update="updateData"
+        />
+      </v-card-text>
+
+      <v-card-actions v-if="$vuetify.breakpoint.mdAndUp">
+        <v-btn
+          data-cy="shift-save"
+          text
+          :disabled="!formValid"
+          color="primary"
+          @click="shiftToSave.uuid === null ? save() : update()"
+        >
+          Save
+        </v-btn>
+        <v-btn data-cy="shift-cancel" text @click="closeMainDialog">
+          Cancel
+        </v-btn>
+
+        <v-spacer></v-spacer>
+        <v-btn
+          v-if="shiftToSave.uuid !== null"
+          data-cy="shift-form-delete-button"
+          text
+          color="error"
+          @click="confirmDialog = true"
+        >
+          Delete
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <v-dialog v-model="confirmDialog" max-width="500px">
+      <v-card data-cy="delete-dialog">
+        <v-card-title>
+          <span class="headline">Delete shift?</span>
+        </v-card-title>
+
+        <v-card-text>
+          Deleting the shift is a permanent action.
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn data-cy="delete-cancel" text @click="confirmDialog = false">
+            Cancel
+          </v-btn>
+          <v-btn data-cy="delete-confirm" color="error" text @click="destroy">
+            Delete
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-dialog>
+</template>
+
+<script>
+import ShiftService from "@/services/shift";
+import ShiftForm from "@/components/shifts/ShiftForm";
+// import { handleApiError } from "@/utils/interceptors";
+
+import { mdiDelete, mdiClose } from "@mdi/js";
+
+export default {
+  name: "ShiftFormDialog",
+  components: { ShiftForm },
+  props: {
+    now: {
+      type: Date,
+      default: () => new Date()
+    },
+    shiftEntity: {
+      type: Object || null,
+      default: null
+    }
+  },
+  data: () => ({
+    confirmDialog: false,
+    formValid: true,
+    mainDialog: true,
+    icons: {
+      mdiDelete,
+      mdiClose
+    },
+    shiftToSave: null
+  }),
+  created() {
+    // Make a copy of the shift we will save.
+    this.shiftToSave = this.shiftEntity;
+  },
+  methods: {
+    updateData(event) {
+      this.shiftToSave = event.shift;
+      this.formValid = event.valid;
+    },
+    closeMainDialog() {
+      this.$emit("close");
+    },
+    destroy() {
+      ShiftService.delete(this.shiftToSave.uuid)
+        .then(() => {
+          this.$emit("refresh");
+        })
+        .finally(() => {
+          this.closeMainDialog();
+        });
+    },
+    update() {
+      ShiftService.update(this.shiftToSave.toPayload(), this.shiftToSave.uuid)
+        .then(() => {
+          this.$emit("refresh");
+        })
+        .finally(() => {
+          this.closeMainDialog();
+        });
+    },
+    save() {
+      ShiftService.create(this.shiftToSave.toPayload())
+        .then(() => {
+          this.$emit("refresh");
+        })
+        .finally(() => {
+          this.closeMainDialog();
+        });
+    }
+  }
+};
+</script>

--- a/src/components/shifts/ShiftFormInput.vue
+++ b/src/components/shifts/ShiftFormInput.vue
@@ -3,11 +3,14 @@
     :value="value"
     label="Note"
     filled
+    :prepend-icon="icons.mdiNoteOutline"
     @input="$emit('input', $event)"
   />
 </template>
 
 <script>
+import { mdiNoteOutline } from "@mdi/js";
+
 export default {
   name: "ShiftFormInput",
   props: {
@@ -15,6 +18,9 @@ export default {
       type: String,
       default: ""
     }
-  }
+  },
+  data: () => ({
+    icons: { mdiNoteOutline }
+  })
 };
 </script>

--- a/src/components/shifts/ShiftFormInput.vue
+++ b/src/components/shifts/ShiftFormInput.vue
@@ -2,7 +2,7 @@
   <v-textarea
     :value="value"
     label="Note"
-    outlined
+    filled
     @input="$emit('input', $event)"
   />
 </template>

--- a/src/components/shifts/ShiftFormSelect.vue
+++ b/src/components/shifts/ShiftFormSelect.vue
@@ -6,7 +6,7 @@
     item-text="text"
     item-value="value"
     return-object
-    outlined
+    filled
     @input="$emit('input', $event)"
   >
   </v-select>

--- a/src/components/shifts/ShiftFormTags.vue
+++ b/src/components/shifts/ShiftFormTags.vue
@@ -12,6 +12,7 @@
     multiple
     filled
     clearable
+    :prepend-icon="icons.mdiTagOutline"
     @input="$emit('input', $event)"
     @change="search = null"
   >
@@ -41,6 +42,8 @@
 <script>
 import { mapGetters } from "vuex";
 
+import { mdiTagOutline } from "@mdi/js";
+
 export default {
   name: "ShiftFormTags",
   props: {
@@ -50,6 +53,7 @@ export default {
     }
   },
   data: () => ({
+    icons: { mdiTagOutline },
     model: [],
     search: null
   }),

--- a/src/components/shifts/ShiftFormTags.vue
+++ b/src/components/shifts/ShiftFormTags.vue
@@ -10,7 +10,7 @@
     label="Add a tag"
     small-chips
     multiple
-    outlined
+    filled
     clearable
     @input="$emit('input', $event)"
     @change="search = null"

--- a/src/components/shifts/ShiftFormTimeInput.vue
+++ b/src/components/shifts/ShiftFormTimeInput.vue
@@ -17,6 +17,7 @@
         dense
         mask="time"
         :readonly="$vuetify.breakpoint.smAndDown"
+        :prepend-icon="prependIcon ? icons.mdiClockOutline : ''"
         @click:append="clickAppend"
         @blur="setTime"
         v-on="$vuetify.breakpoint.smAndDown ? on : ''"
@@ -35,7 +36,7 @@
 import { format } from "date-fns";
 import { Shift } from "@/models/ShiftModel";
 
-import { mdiClockIn, mdiClockOut } from "@mdi/js";
+import { mdiClockOutline } from "@mdi/js";
 
 function validHourMinute(value) {
   let hour, minute;
@@ -67,6 +68,10 @@ export default {
     label: {
       type: String,
       default: ""
+    },
+    prependIcon: {
+      type: Boolean,
+      default: false
     }
   },
   data: () => ({
@@ -76,7 +81,7 @@ export default {
       start: "end",
       end: "start"
     },
-    icons: { mdiClockIn: mdiClockIn, mdiClockOut: mdiClockOut }
+    icons: { mdiClockOutline }
   }),
   computed: {
     time: {

--- a/src/components/shifts/ShiftFormTimeInput.vue
+++ b/src/components/shifts/ShiftFormTimeInput.vue
@@ -1,44 +1,39 @@
 <template>
-  <div>
-    <v-text-field
+  <v-menu
+    ref="menu"
+    v-model="menu"
+    :close-on-content-click="false"
+    transition="scale-transition"
+    offset-y
+  >
+    <template v-slot:activator="{ on }">
+      <v-text-field
+        v-model="data"
+        :data-time-value="data"
+        :data-cy="type"
+        return-masked-value
+        hide-details
+        filled
+        dense
+        mask="time"
+        :readonly="$vuetify.breakpoint.smAndDown"
+        @click:append="clickAppend"
+        @blur="setTime"
+        v-on="$vuetify.breakpoint.smAndDown ? on : ''"
+      ></v-text-field>
+    </template>
+    <v-time-picker
+      v-if="$vuetify.breakpoint.smAndDown"
       v-model="data"
-      v-mask="'##:##'"
-      :data-time-value="data"
-      :data-cy="type"
-      return-masked-value
-      :error-messages="errors"
-      :label="label"
-      outlined
-      mask="time"
-      :append-icon="type === 'start' ? icons.mdiClockIn : icons.mdiClockOut"
-      hint="HH:mm"
-      :persistent-hint="true"
-      @click:append="clickAppend"
-      @blur="setTime"
-    ></v-text-field>
-
-    <TheDialog
-      v-if="dialog"
-      :max-width="400"
-      :persistent="false"
-      @click:outside="dialog = false"
-    >
-      <template v-slot:content>
-        <v-time-picker
-          v-model="data"
-          format="24hr"
-          full-width
-          @click:minute="setTime"
-        ></v-time-picker>
-      </template>
-    </TheDialog>
-  </div>
+      format="24hr"
+      @click:minute="setTime"
+    ></v-time-picker>
+  </v-menu>
 </template>
 
 <script>
 import { format } from "date-fns";
 import { Shift } from "@/models/ShiftModel";
-import TheDialog from "@/components/TheDialog";
 
 import { mdiClockIn, mdiClockOut } from "@mdi/js";
 
@@ -56,9 +51,6 @@ function validHourMinute(value) {
 
 export default {
   name: "ShiftFormTimeInput",
-  components: {
-    TheDialog
-  },
   props: {
     value: {
       type: Object,
@@ -84,8 +76,7 @@ export default {
       start: "end",
       end: "start"
     },
-    icons: { mdiClockIn: mdiClockIn, mdiClockOut: mdiClockOut },
-    dialog: false
+    icons: { mdiClockIn: mdiClockIn, mdiClockOut: mdiClockOut }
   }),
   computed: {
     time: {

--- a/src/components/shifts/ShiftFormType.vue
+++ b/src/components/shifts/ShiftFormType.vue
@@ -1,0 +1,48 @@
+<template>
+  <v-row align="center">
+    <v-icon class="ml-4 mr-2">{{ icons.mdiInformationOutline }}</v-icon>
+    <v-radio-group v-model="radios" row>
+      <v-radio
+        v-for="type in types"
+        :key="type.value"
+        :label="type.text"
+        :value="type.value"
+        :color="typeColors[type.value]"
+      ></v-radio>
+    </v-radio-group>
+  </v-row>
+</template>
+
+<script>
+import { mdiInformationOutline } from "@mdi/js";
+import { SHIFT_TYPES } from "@/models/ShiftModel";
+import { SHIFT_TYPE_COLORS } from "@/utils/colors";
+
+export default {
+  name: "ShiftFormType",
+  props: {
+    value: {
+      type: Object,
+      default: () => ({ text: "Shift", value: "st" })
+    }
+  },
+  data: () => ({
+    icons: {
+      mdiInformationOutline
+    },
+    types: SHIFT_TYPES,
+    typeColors: SHIFT_TYPE_COLORS
+  }),
+  computed: {
+    radios: {
+      get() {
+        return this.value.value;
+      },
+      set(value) {
+        const selected = this.types.find(type => type.value === value);
+        this.$emit("input", selected);
+      }
+    }
+  }
+};
+</script>

--- a/src/components/shifts/ShiftFormType.vue
+++ b/src/components/shifts/ShiftFormType.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-row align="center">
-    <v-icon class="ml-4 mr-2">{{ icons.mdiBriefcaseOutline }}</v-icon>
+  <v-row align="center" class="pl-4">
+    <v-icon>{{ icons.mdiBriefcaseOutline }}</v-icon>
     <v-radio-group v-model="radios" row>
       <v-radio
         v-for="type in types"

--- a/src/components/shifts/ShiftFormType.vue
+++ b/src/components/shifts/ShiftFormType.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-row align="center" class="pl-4">
+  <v-row align="end" class="pl-4">
     <v-icon>{{ icons.mdiBriefcaseOutline }}</v-icon>
-    <v-radio-group v-model="radios" row>
+    <v-radio-group v-model="radios" row hide-details dense>
       <v-radio
         v-for="type in types"
         :key="type.value"

--- a/src/components/shifts/ShiftFormType.vue
+++ b/src/components/shifts/ShiftFormType.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row align="center">
-    <v-icon class="ml-4 mr-2">{{ icons.mdiInformationOutline }}</v-icon>
+    <v-icon class="ml-4 mr-2">{{ icons.mdiBriefcaseOutline }}</v-icon>
     <v-radio-group v-model="radios" row>
       <v-radio
         v-for="type in types"
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { mdiInformationOutline } from "@mdi/js";
+import { mdiBriefcaseOutline } from "@mdi/js";
 import { SHIFT_TYPES } from "@/models/ShiftModel";
 import { SHIFT_TYPE_COLORS } from "@/utils/colors";
 
@@ -28,7 +28,7 @@ export default {
   },
   data: () => ({
     icons: {
-      mdiInformationOutline
+      mdiBriefcaseOutline
     },
     types: SHIFT_TYPES,
     typeColors: SHIFT_TYPE_COLORS

--- a/src/components/shifts/ShiftList.vue
+++ b/src/components/shifts/ShiftList.vue
@@ -31,7 +31,6 @@
           :data-cy="'shift-list-item-' + index"
           :editable="editable"
           :item="item"
-          :active="active"
           :toggle="toggle"
         />
       </template>
@@ -75,7 +74,7 @@ export default {
       required: true
     },
     shifts: {
-      type: Object,
+      type: Array,
       required: true
     },
     title: {

--- a/src/models/ShiftModel.js
+++ b/src/models/ShiftModel.js
@@ -21,7 +21,7 @@ function defaultValueTime(type) {
   return today;
 }
 
-const SHIFT_TYPES = [
+export const SHIFT_TYPES = [
   { text: "Shift", value: "st" },
   { text: "Sick", value: "sk" },
   { text: "Vacation", value: "vn" }

--- a/src/models/ShiftModel.js
+++ b/src/models/ShiftModel.js
@@ -22,8 +22,8 @@ function defaultValueTime(type) {
 }
 
 export const SHIFT_TYPES = [
-  { text: "Shift", value: "st" },
-  { text: "Sick", value: "sk" },
+  { text: "Normal shift", value: "st" },
+  { text: "Sick leave", value: "sk" },
   { text: "Vacation", value: "vn" }
 ];
 

--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,6 @@ const Home = () => import("@/views/Home");
 const ViewLogin = () => import("@/views/ViewLogin");
 const ViewLogout = () => import("@/views/ViewLogout");
 const ViewCalendar = () => import("@/views/ViewCalendar.vue");
-const ViewShiftForm = () => import("@/views/ViewShiftForm");
 const ViewShiftList = () => import("@/views/ViewShiftList");
 const ViewContractForm = () => import("@/views/ViewContractForm");
 const ViewContractList = () => import("@/views/ViewContractList");
@@ -47,18 +46,6 @@ const router = new Router({
           path: "/:type/:year/:month/:day",
           name: "calendar",
           component: ViewCalendar,
-          props: true
-        },
-        {
-          path: "/shifts/:uuid/edit",
-          name: "editShift",
-          component: ViewShiftForm,
-          props: true
-        },
-        {
-          path: "/shifts/create",
-          name: "createShift",
-          component: ViewShiftForm,
           props: true
         },
         {

--- a/src/views/ViewCalendar.vue
+++ b/src/views/ViewCalendar.vue
@@ -3,6 +3,7 @@
     :initial-focus="focus"
     :initial-type="type"
     @updateRange="updateRange"
+    @refresh="refresh"
   >
   </Calendar>
 </template>
@@ -69,10 +70,13 @@ export default {
     }
   },
   mounted() {
-    this.$store.dispatch("shift/queryShifts");
-    this.$store.dispatch("contract/queryContracts");
+    this.refresh();
   },
   methods: {
+    refresh() {
+      this.$store.dispatch("shift/queryShifts");
+      this.$store.dispatch("contract/queryContracts");
+    },
     updateRange({ type, start: { day, month, year } }) {
       this.now = type === "day" ? new Date(year, month - 1, day) : new Date();
 


### PR DESCRIPTION
- Schichten werden nicht mehr in eigenen Views (mit eigener URL) editiert, sondern in einem Dialog.
- Design von `ShiftForm` komplett geändert.
- `TimePicker` wird nur noch in mobiler Ansicht genutzt.
- `v-mask` wurde entfernt.