### PR TITLE
Refactor reporting

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -120,7 +120,9 @@ export default {
       if (this.reports.length < 1) return "00:00";
 
       let creditHours = String(Math.floor(this.latestReport.duration / 60));
-      let creditMinutes = String(Math.floor(this.latestReport.duration % 60));
+      let creditMinutes = String(
+        Math.abs(Math.floor(this.latestReport.duration % 60))
+      );
 
       if (creditHours.length < 2) {
         creditHours = "0" + creditHours;

--- a/src/components/DashboardConflicts.vue
+++ b/src/components/DashboardConflicts.vue
@@ -25,7 +25,7 @@
     </v-row>
 
     <v-card-actions>
-      <v-btn color="error" text block :to="{ name: 'shiftList' }">
+      <v-btn color="error" text block :to="{ path: '/overlap' }">
         {{ $t("actions.resolve") }}
       </v-btn>
     </v-card-actions>

--- a/src/components/DashboardConflicts.vue
+++ b/src/components/DashboardConflicts.vue
@@ -25,26 +25,48 @@
     </v-row>
 
     <v-card-actions>
-      <v-btn color="error" text block :to="{ path: '/overlap' }">
+      <v-btn color="error" text block @click="dialog = true">
         {{ $t("actions.resolve") }}
       </v-btn>
     </v-card-actions>
+
+    <v-dialog
+      v-model="dialog"
+      :fullscreen="$vuetify.breakpoint.smAndDown"
+      max-width="600"
+      persistent
+      no-click-animation
+      @keydown.esc="dialog = false"
+    >
+      <CalendarOverlap
+        :shifts="shifts"
+        :month="month"
+        @close="dialog = false"
+      />
+    </v-dialog>
   </v-card>
 </template>
 
 <script>
 import { mdiAlert, mdiCheckBold } from "@mdi/js";
 import { getOverlappingShifts } from "@/utils/shift";
+import CalendarOverlap from "@/components/calendar/CalendarOverlap";
 
 export default {
   name: "DashboardConflicts",
+  components: { CalendarOverlap },
   props: {
+    month: {
+      type: String,
+      required: true
+    },
     shifts: {
       type: Array,
       required: true
     }
   },
   data: () => ({
+    dialog: false,
     icons: {
       mdiAlert,
       mdiCheckBold

--- a/src/components/DashboardConflicts.vue
+++ b/src/components/DashboardConflicts.vue
@@ -48,6 +48,7 @@
 </template>
 
 <script>
+import { format } from "date-fns";
 import { mdiAlert, mdiCheckBold } from "@mdi/js";
 import { getOverlappingShifts } from "@/utils/shift";
 import CalendarOverlap from "@/components/calendar/CalendarOverlap";
@@ -58,7 +59,7 @@ export default {
   props: {
     month: {
       type: String,
-      required: true
+      default: format(new Date(), "yyyy-MM")
     },
     shifts: {
       type: Array,

--- a/src/components/DataFilter.vue
+++ b/src/components/DataFilter.vue
@@ -124,6 +124,7 @@ export default {
     data() {
       return {
         date: this.date,
+        carryover: () => this.carryover,
         hasNextMonth: () => this.hasNextMonth,
         hasPrevMonth: () => this.hasPrevMonth,
         isCurrentMonthLocked: this.isCurrentMonthLocked,
@@ -145,6 +146,19 @@ export default {
     },
     hasPrevMonth() {
       return isBefore(new Date(this.data.months.min), new Date(this.data.date));
+    },
+    previousMonth() {
+      if (!this.hasPrevMonth) return 0;
+
+      const monthIndex = this.months.months.indexOf(this.date);
+      return this.months.months[monthIndex - 1];
+    },
+    carryover() {
+      if (!this.hasPrevMonth) return 0;
+
+      return this.reports.find(
+        report => report.date.slice(0, 7) === this.previousMonth
+      ).duration;
     }
   },
   watch: {

--- a/src/components/DataFilter.vue
+++ b/src/components/DataFilter.vue
@@ -49,8 +49,30 @@ export default {
       shiftsVuex: "shift/shifts",
       reportsVuex: "report/reports"
     }),
+    isCurrentMonthLocked() {
+      return this.lockedMonths
+        .filter(month => Object.values(month)[0] === true)
+        .map(month => Object.keys(month)[0])
+        .includes(this.date);
+    },
     firstUnlockedMonth() {
-      return Object.keys(this.lockedMonths[0])[0];
+      const allLocked = this.lockedMonths
+        .map(month => Object.entries(month)[0][1])
+        .every(item => item === true);
+
+      if (allLocked) {
+        console.log(Object.entries(this.lockedMonths)[0]);
+        return this.lockedMonths.map(month => Object.keys(month)[0])[
+          this.lockedMonths.length - 1
+        ];
+      }
+
+      return Object.entries(
+        this.lockedMonths.find(month => {
+          const entries = Object.entries(month)[0];
+          return entries[1] === false;
+        })
+      )[0][0];
     },
     lockedMonths() {
       return this.reports.map(report => {
@@ -105,6 +127,8 @@ export default {
         date: this.date,
         hasNextMonth: () => this.hasNextMonth,
         hasPrevMonth: () => this.hasPrevMonth,
+        isCurrentMonthLocked: this.isCurrentMonthLocked,
+        firstUnlockedMonth: this.firstUnlockedMonth,
         nextMonth: this.nextMonth,
         prevMonth: this.prevMonth,
         months: this.months,
@@ -132,7 +156,7 @@ export default {
     }
   },
   async created() {
-    this.setDate(this.date);
+    this.setDate(this.firstUnlockedMonth);
     try {
       await Promise.all([
         this.$store.dispatch("shift/queryShifts"),

--- a/src/components/DataFilter.vue
+++ b/src/components/DataFilter.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <slot v-if="loading" name="loading">
+      <div>Loading...</div>
+    </slot>
+    <slot v-else-if="error">
+      <div>Something went wrong...</div>
+    </slot>
+    <slot v-else v-bind="{ data }"></slot>
+  </div>
+</template>
+
+<script>
+import { min, max, format } from "date-fns";
+import { log } from "@/utils/log";
+export default {
+  name: "DataFilter",
+  data: () => ({
+    error: false,
+    loading: true,
+    data: null
+  }),
+  async created() {
+    try {
+      const [shifts, contracts, reports] = await Promise.all([
+        this.$store.dispatch("shift/queryShifts"),
+        this.$store.dispatch("contract/queryContracts"),
+        this.$store.dispatch("report/list")
+      ]);
+
+      const months = reports.map(report => report.date.slice(0, 7));
+      const dates = reports.map(report => new Date(report.date));
+
+      this.data = {
+        shifts,
+        contracts,
+        reports,
+        months: {
+          months,
+          min: format(min(dates), "yyyy-MM-dd"),
+          max: format(max(dates), "yyyy-MM-dds")
+        },
+        allowedMonths: value => {
+          return months.includes(value);
+        }
+      };
+    } catch (error) {
+      log(error);
+      this.error = true;
+    } finally {
+      this.loading = false;
+    }
+  }
+};
+</script>

--- a/src/components/DataFilter.vue
+++ b/src/components/DataFilter.vue
@@ -61,7 +61,6 @@ export default {
         .every(item => item === true);
 
       if (allLocked) {
-        console.log(Object.entries(this.lockedMonths)[0]);
         return this.lockedMonths.map(month => Object.keys(month)[0])[
           this.lockedMonths.length - 1
         ];

--- a/src/components/ReportCard.vue
+++ b/src/components/ReportCard.vue
@@ -147,10 +147,10 @@ export default {
   computed: {
     rows() {
       return [
-        {
-          name: "Übertrag aus dem letzten Monat",
-          value: minutesToHHMM(this.carryover)
-        },
+        // {
+        //   name: "Übertrag aus dem letzten Monat",
+        //   value: minutesToHHMM(this.carryover)
+        // },
         {
           name: "Monatliche Arbeitszeit",
           value: minutesToHHMM(this.debit)
@@ -158,11 +158,11 @@ export default {
         {
           name: "Geleistete Arbeitszeit",
           value: minutesToHHMM(this.timeWorked)
-        },
-        {
-          name: "Übertrag Folgemonat",
-          value: minutesToHHMM(this.report.duration)
         }
+        // {
+        //   name: "Übertrag Folgemonat",
+        //   value: minutesToHHMM(this.report.duration)
+        // }
       ];
     },
     timeWorked() {

--- a/src/components/ReportCard.vue
+++ b/src/components/ReportCard.vue
@@ -117,7 +117,12 @@ export default {
       return minutesToHHMM(contract.minutes);
     },
     credit() {
-      return minutesToHHMM(this.report.duration);
+      let credit = minutesToHHMM(this.report.duration);
+
+      if (this.report.duration < 0) {
+        credit = `-${credit}`;
+      }
+      return credit;
     },
     creditDebit() {
       return `${this.credit} ${this.$t("reports.of")} ${this.debit}`;

--- a/src/components/ReportCard.vue
+++ b/src/components/ReportCard.vue
@@ -30,11 +30,6 @@
         <v-col>Aktuelles Zeitguthaben</v-col>
         <v-col>{{ credit }}</v-col>
       </v-row>
-
-      <v-row>
-        <v-col>Übertrag Folgemonat</v-col>
-        <v-col>{{ carryNextMonth | minutesToHHMM }}</v-col>
-      </v-row>
     </v-card-text>
 
     <v-card-actions class="px-1">
@@ -167,9 +162,6 @@ export default {
     };
   },
   computed: {
-    carryNextMonth() {
-      return 0;
-    },
     timeWorked() {
       const reduced = this.shifts.reduce((acc, cur) => {
         const dateA = new Date(cur.date.start);

--- a/src/components/ReportCard.vue
+++ b/src/components/ReportCard.vue
@@ -27,7 +27,18 @@
           Download
         </v-btn>
 
-        <ConfirmationDialog
+        <v-btn
+          v-else
+          :loading="loading"
+          :outlined="loading"
+          text
+          color="primary"
+          @click="request"
+        >
+          {{ $t("actions.request") }}
+        </v-btn>
+
+        <!-- <ConfirmationDialog
           v-else
           :confirmation-button="{
             text: $t('actions.continue'),
@@ -54,7 +65,7 @@
           <template v-slot:text>
             {{ $t("reports.exportAlert") }}
           </template>
-        </ConfirmationDialog>
+        </ConfirmationDialog> -->
       </v-card-actions>
     </v-card>
   </v-col>
@@ -63,15 +74,15 @@
 <script>
 import { format, parseISO } from "date-fns";
 import ReportService from "@/services/report";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
+// import ConfirmationDialog from "@/components/ConfirmationDialog";
 
 import { minutesToHHMM } from "@/utils/time";
 
 export default {
   name: "ReportCard",
-  components: {
-    ConfirmationDialog
-  },
+  // components: {
+  //   ConfirmationDialog
+  // },
   filters: {
     formatDate(date) {
       return format(parseISO(date), "MMMM yyyy");

--- a/src/components/TheNavigationDrawer.vue
+++ b/src/components/TheNavigationDrawer.vue
@@ -173,7 +173,7 @@ export default {
         },
         {
           text: this.$t("app.reports"),
-          to: { name: "reportList" },
+          to: { name: "reporting" },
           icon: mdiFileChart,
           loggedOut: false
         }

--- a/src/components/TheNavigationToolbar.vue
+++ b/src/components/TheNavigationToolbar.vue
@@ -58,7 +58,7 @@ export default {
         },
         {
           text: this.$t("app.reports"),
-          to: { name: "reportList" },
+          to: { name: "reporting" },
           icon: mdiFileChart,
           loggedOut: false
         }

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -178,7 +178,7 @@ export default {
           duration: duration,
           selectedEventDuration: shift.representationalDuration(),
           contract: contract,
-          exported: shift.exported
+          locked: shift.locked
         };
       });
     },

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -93,9 +93,6 @@ export default {
       return [...currentOverlap, ...otherShifts];
     }
   },
-  mounted() {
-    this.$refs.calendar.checkChange();
-  },
   methods: {
     async refresh() {
       await this.$store.dispatch("shift/queryShifts");

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -1,0 +1,129 @@
+<template>
+  <div v-if="overlappingShifts.length > 1">
+    <v-row>
+      <v-btn :disabled="index < 1" @click="index--">Previous</v-btn>
+      <v-spacer></v-spacer>
+      <span>{{ index + 1 }} / {{ overlappingShifts.length }}</span>
+      <v-spacer></v-spacer>
+      <v-btn :disabled="index == overlappingShifts.length - 1" @click="index++">
+        Next
+      </v-btn>
+    </v-row>
+    <v-calendar
+      ref="calendar"
+      v-model="focus"
+      color="primary"
+      type="category"
+      category-show-all
+      :categories="categories"
+      :events="overlap"
+      @click:event="handleEventClick"
+    ></v-calendar>
+
+    <FormDialog
+      v-if="showForm"
+      entity-name="shift"
+      :entity="shiftEntity"
+      @close="closeFormDialog"
+      @refresh="refresh"
+    />
+  </div>
+  <v-card v-else>
+    <placeholder name="UndrawEmpty">
+      There are no overlapping shifts. You're good!
+    </placeholder>
+  </v-card>
+</template>
+
+<script>
+import { getOverlappingShifts } from "@/utils/shift";
+import { mapGetters } from "vuex";
+
+import { Shift } from "@/models/ShiftModel";
+import FormDialog from "@/components/FormDialog";
+
+export default {
+  name: "CalendarOverlap",
+  components: { FormDialog },
+  data: () => ({
+    index: 0,
+    showForm: false,
+    shiftEntity: null,
+    focus: "",
+    categories: ["All shift", "Overlapping shift"]
+  }),
+  computed: {
+    ...mapGetters({
+      shifts: "shift/shifts"
+    }),
+    overlappingShifts() {
+      return getOverlappingShifts(this.shifts).sort((a, b) => {
+        return new Date(a.modified_at) - new Date(b.modified_at);
+      });
+    },
+    overlap() {
+      if (this.overlappingShifts.length < 1) return [];
+
+      const currentOverlap = this.overlappingShifts[this.index].map(
+        (shift, index) => {
+          return {
+            name: `Shift ${index + 1}`,
+            start: new Date(shift.date.start),
+            end: new Date(shift.date.end),
+            category: this.categories[1],
+            timed: true,
+            uuid: shift.uuid
+          };
+        }
+      );
+      const overlappingId = currentOverlap.map(shift => shift.uuid);
+      const otherShifts = this.shifts
+        .filter(shift => !overlappingId.includes(shift.uuid))
+        .map(shift => {
+          return {
+            name: `Shift`,
+            start: new Date(shift.date.start),
+            end: new Date(shift.date.end),
+            category: this.categories[0],
+            timed: true,
+            uuid: shift.uuid
+          };
+        });
+
+      return [...currentOverlap, ...otherShifts];
+    }
+  },
+  mounted() {
+    this.$refs.calendar.checkChange();
+  },
+  methods: {
+    async refresh() {
+      await this.$store.dispatch("shift/queryShifts");
+    },
+    handleEventClick(event) {
+      this.editShift(event.event.uuid);
+    },
+    editShift(uuid) {
+      const shift = this.shifts.find(shift => shift.uuid === uuid);
+      this.shiftEntity = new Shift(shift);
+      this.showForm = true;
+    },
+    closeFormDialog() {
+      this.showForm = false;
+      this.shiftEntity = null;
+    },
+    getEventColor(event) {
+      return event.color;
+    },
+    setToday() {
+      this.focus = "";
+    },
+    prev() {
+      this.$refs.calendar.prev();
+    },
+    next() {
+      this.$refs.calendar.next();
+    }
+  }
+};
+</script>

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="overlappingShifts.length > 1">
+  <div v-if="overlappingShifts.length > 0">
     <v-row>
       <v-btn :disabled="index < 1" @click="index--">Previous</v-btn>
       <v-spacer></v-spacer>

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -17,6 +17,7 @@
       category-show-all
       :categories="categories"
       :events="events"
+      :event-color="getEventColor"
       @click:event="handleEventClick"
     ></v-calendar>
 
@@ -73,7 +74,8 @@ export default {
           end: new Date(shift.date.end),
           category: this.categories[1],
           timed: true,
-          uuid: shift.uuid
+          uuid: shift.uuid,
+          color: index === 0 ? "green" : "red"
         };
       });
     },
@@ -88,7 +90,8 @@ export default {
             end: new Date(shift.date.end),
             category: this.categories[0],
             timed: true,
-            uuid: shift.uuid
+            uuid: shift.uuid,
+            color: "grey"
           };
         });
     },

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -1,25 +1,36 @@
 <template>
-  <div v-if="lengthAllOverlaps > 0">
-    <v-row>
-      <v-btn :disabled="index < 1" @click="prev">Previous</v-btn>
-      <v-spacer></v-spacer>
-      <span>{{ index + 1 }} / {{ lengthAllOverlaps }}</span>
-      <v-spacer></v-spacer>
-      <v-btn :disabled="index == lengthAllOverlaps - 1" @click="next">
-        Next
+  <v-card v-if="lengthAllOverlaps > 0">
+    <v-toolbar flat>
+      <v-btn v-if="$vuetify.breakpoint.smAndDown" icon @click="$emit('close')">
+        <v-icon>{{ icons.mdiClose }}</v-icon>
       </v-btn>
-    </v-row>
-    <v-calendar
-      ref="calendar"
-      v-model="focus"
-      color="primary"
-      type="category"
-      category-show-all
-      :categories="categories"
-      :events="events"
-      :event-color="getEventColor"
-      @click:event="handleEventClick"
-    ></v-calendar>
+      <v-toolbar-title>Resolving {{ month }}</v-toolbar-title>
+    </v-toolbar>
+
+    <v-card-text>
+      <v-row align="center" justify="center">
+        <v-btn :disabled="index < 1" text @click="prev">
+          <v-icon>{{ icons.mdiChevronLeft }}</v-icon>
+        </v-btn>
+
+        <span>{{ index + 1 }} / {{ lengthAllOverlaps }}</span>
+
+        <v-btn :disabled="index == lengthAllOverlaps - 1" text @click="next">
+          <v-icon>{{ icons.mdiChevronRight }}</v-icon>
+        </v-btn>
+      </v-row>
+      <v-calendar
+        ref="calendar"
+        v-model="focus"
+        color="primary"
+        type="category"
+        category-show-all
+        :categories="categories"
+        :events="events"
+        :event-color="getEventColor"
+        @click:event="handleEventClick"
+      ></v-calendar>
+    </v-card-text>
 
     <FormDialog
       v-if="showForm"
@@ -28,7 +39,7 @@
       @close="closeFormDialog"
       @refresh="refresh"
     />
-  </div>
+  </v-card>
   <v-card v-else>
     <placeholder name="UndrawEmpty">
       There are no overlapping shifts. You're good!
@@ -39,7 +50,7 @@
 <script>
 import { format } from "date-fns";
 import { getOverlappingShifts } from "@/utils/shift";
-import { mapGetters } from "vuex";
+import { mdiClose, mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 
 import { Shift } from "@/models/ShiftModel";
 import FormDialog from "@/components/FormDialog";
@@ -47,7 +58,22 @@ import FormDialog from "@/components/FormDialog";
 export default {
   name: "CalendarOverlap",
   components: { FormDialog },
+  props: {
+    month: {
+      type: String,
+      required: true
+    },
+    shifts: {
+      type: Array,
+      required: true
+    }
+  },
   data: () => ({
+    icons: {
+      mdiClose,
+      mdiChevronLeft,
+      mdiChevronRight
+    },
     index: 0,
     showForm: false,
     shiftEntity: null,
@@ -55,9 +81,6 @@ export default {
     categories: ["All shift", "Overlapping shift"]
   }),
   computed: {
-    ...mapGetters({
-      shifts: "shift/shifts"
-    }),
     allOverlappingShifts() {
       return getOverlappingShifts(this.shifts).sort((a, b) => {
         return new Date(a[0].date.start) - new Date(b[1].date.start);

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card v-if="lengthAllOverlaps > 0">
     <v-toolbar flat>
-      <v-btn v-if="$vuetify.breakpoint.smAndDown" icon @click="$emit('close')">
+      <v-btn icon @click="$emit('close')">
         <v-icon>{{ icons.mdiClose }}</v-icon>
       </v-btn>
       <v-toolbar-title>Resolving {{ month }}</v-toolbar-title>

--- a/src/components/calendar/CalendarOverlap.vue
+++ b/src/components/calendar/CalendarOverlap.vue
@@ -91,14 +91,15 @@ export default {
     },
     focussedOverlap() {
       return this.allOverlappingShifts[this.index].map((shift, index) => {
+        const labels = ["A", "B"];
         return {
-          name: `Shift ${index + 1}`,
+          name: `(${labels[index]}) ` + this.$t(`shifts.types.${shift.type}`),
           start: new Date(shift.date.start),
           end: new Date(shift.date.end),
           category: this.categories[1],
           timed: true,
           uuid: shift.uuid,
-          color: index === 0 ? "green" : "red"
+          color: index === 0 ? "grey" : "orange"
         };
       });
     },
@@ -108,13 +109,13 @@ export default {
         .filter(shift => !overlappingId.includes(shift.uuid))
         .map(shift => {
           return {
-            name: `Shift`,
+            name: this.$t(`shifts.types.${shift.type}`),
             start: new Date(shift.date.start),
             end: new Date(shift.date.end),
             category: this.categories[0],
             timed: true,
             uuid: shift.uuid,
-            color: "grey"
+            color: "primary"
           };
         });
     },

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -169,7 +169,7 @@ export default {
       selectedContract: "selectedContract"
     }),
     shiftExported() {
-      return this.shift.exported;
+      return this.shift.locked;
     },
     tags() {
       return this.shift.tags.join(", ");

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -105,7 +105,7 @@ import { Shift } from "@/models/ShiftModel";
 import { Contract } from "@/models/ContractModel";
 
 import { mapGetters } from "vuex";
-import { format, isAfter, isBefore } from "date-fns";
+import { format, isAfter, isBefore, isSameDay } from "date-fns";
 
 import { startEndHours } from "@/utils/time";
 
@@ -252,8 +252,10 @@ export default {
       // Do nothing if current date is inside the
       // selected contract
       if (
-        isBefore(new Date(contractStart), this.shift.date.start) &&
-        isAfter(new Date(contractEnd), this.shift.date.end)
+        (isBefore(new Date(contractStart), this.shift.date.start) &&
+          isAfter(new Date(contractEnd), this.shift.date.end)) ||
+        isSameDay(new Date(contractStart), this.shift.date.start) ||
+        isSameDay(new Date(contractEnd), this.shift.date.end)
       ) {
         return;
       }

--- a/src/components/shifts/ShiftList.vue
+++ b/src/components/shifts/ShiftList.vue
@@ -123,7 +123,7 @@ export default {
       return this.hasSelectedShifts && !this.hasSelectedAllShifts;
     },
     hasExportedShifts() {
-      return this.shifts.map(shift => shift.exported).every(item => !!item);
+      return this.shifts.map(shift => shift.locked).every(item => !!item);
     }
   },
   watch: {

--- a/src/components/shifts/ShiftListItem.vue
+++ b/src/components/shifts/ShiftListItem.vue
@@ -1,9 +1,9 @@
 <template>
-  <v-list-item :disabled="item.exported || !editable">
+  <v-list-item :disabled="item.locked || !editable">
     <template v-slot:default="{ active }">
       <v-list-item-action v-if="editable">
         <v-checkbox
-          :disabled="!editable || item.exported"
+          :disabled="!editable || item.locked"
           :value="active"
         ></v-checkbox>
       </v-list-item-action>
@@ -12,7 +12,7 @@
         <v-list-item-title>
           {{ item.date.start | formatDay }}
         </v-list-item-title>
-        <v-list-item-subtitle :class="item.exported ? '' : 'text--primary'">
+        <v-list-item-subtitle :class="item.locked ? '' : 'text--primary'">
           {{ item.date.start | formatTime }} -
           {{ item.date.end | formatTime }}
           ({{ item.representationalDuration("hm") }})

--- a/src/factories/undrawFactory.js
+++ b/src/factories/undrawFactory.js
@@ -6,7 +6,8 @@ const repositories = {
   UndrawFinishLine: () => import("vue-undraw/UndrawFinishLine"),
   UndrawDigitalNomad: () => import("vue-undraw/UndrawDigitalNomad"),
   UndrawSynchronize: () => import("vue-undraw/UndrawSynchronize"),
-  UndrawBlankCanvas: () => import("vue-undraw/UndrawBlankCanvas")
+  UndrawBlankCanvas: () => import("vue-undraw/UndrawBlankCanvas"),
+  UndrawEmpty: () => import("vue-undraw/UndrawEmpty")
 };
 
 export const UndrawFactory = {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -217,7 +217,8 @@
     "exportAlert": "Wenn du fortfährst, kannst du die Schichten des jeweiligen Monats nicht mehr ändern.",
     "exported": "Exportiert",
     "generate": "Stundenzettel erstellen",
-    "of": "von"
+    "of": "von",
+    "personnelNumberMissing": "Bitte füge deine Personalnummer in den Einstellungen hinzu."
   },
   "selectContract": {
     "hint": "Ändere den Vertrag, um andere Daten zu sehen"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -217,7 +217,8 @@
     "exportAlert": "Once you generate the report, you will not be able to add or update shifts in the corresponding month",
     "exported": "Exported",
     "generate": "Generate report",
-    "of": "of"
+    "of": "of",
+    "personnelNumberMissing": "Please add your personnel number in your user settings."
   },
   "selectContract": {
     "hint": "Change the contract to see different data"

--- a/src/models/ShiftModel.js
+++ b/src/models/ShiftModel.js
@@ -35,7 +35,7 @@ export class Shift {
     type = null,
     note = null,
     tags = null,
-    exported = null
+    locked = null
   } = {}) {
     this.uuid = is(String, uuid) ? uuid : null;
     this.user = is(String, user) ? user : null;
@@ -53,7 +53,7 @@ export class Shift {
       : SHIFT_TYPES.find(item => item.value === type);
     this.note = is(String, note) ? note : "";
     this.tags = is(Array, tags) ? tags : [];
-    this.exported = exported === null ? false : exported;
+    this.locked = locked === null ? false : locked;
   }
 
   get start() {
@@ -120,7 +120,7 @@ export class Shift {
       stopped: format(this.end, "yyyy-MM-dd HH:mm:ssXXX"),
       duration: this.representationalDuration,
       was_reviewed: this.reviewed,
-      was_exported: this.exported
+      locked: this.locked
     };
   }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -132,7 +132,6 @@ router.beforeEach(async (to, from, next) => {
     const contractRoutes = [
       "dashboard",
       "shiftList",
-      "reportList",
       "calendar",
       "reporting",
       "debug"

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -134,6 +134,7 @@ router.beforeEach(async (to, from, next) => {
       "shiftList",
       "reportList",
       "calendar",
+      "reporting",
       "debug"
     ];
     const contractMatch = contracts.find(

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -33,7 +33,8 @@ export const routes = [
         component: CalendarOverlap
       },
       {
-        path: "/reporting",
+        path: "/reporting/:contract?",
+        name: "reporting",
         component: Reporting
       },
       {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -4,7 +4,6 @@ const ViewCalendar = () => import("@/views/ViewCalendar.vue");
 const ViewShiftList = () => import("@/views/ViewShiftList");
 const ViewContractForm = () => import("@/views/ViewContractForm");
 const ViewContractList = () => import("@/views/ViewContractList");
-const ViewReportList = () => import("@/views/ViewReportList");
 const ViewHelp = () => import("@/views/ViewHelp");
 const Settings = () => import("@/views/Settings");
 const ViewDebug = () => import("@/views/ViewDebug");
@@ -17,7 +16,6 @@ const Onboarding = () => import("@/views/Onboarding");
 const FAQ = () => import("@/views/FAQ");
 const NotFound = () => import("@/views/NotFound");
 const Reporting = () => import("@/views/Reporting");
-const CalendarOverlap = () => import("@/components/calendar/CalendarOverlap");
 
 export const routes = [
   {
@@ -28,15 +26,6 @@ export const routes = [
     path: "/",
     component: Home,
     children: [
-      {
-        path: "/overlap",
-        component: CalendarOverlap
-      },
-      {
-        path: "/reporting/:contract?",
-        name: "reporting",
-        component: Reporting
-      },
       {
         path: "/404",
         name: "404",
@@ -121,8 +110,8 @@ export const routes = [
       },
       {
         path: "/reports/:contract?",
-        name: "reportList",
-        component: ViewReportList
+        name: "reporting",
+        component: Reporting
       },
       {
         path: "/settings",

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -17,6 +17,7 @@ const Onboarding = () => import("@/views/Onboarding");
 const FAQ = () => import("@/views/FAQ");
 const NotFound = () => import("@/views/NotFound");
 const Reporting = () => import("@/views/Reporting");
+const CalendarOverlap = () => import("@/components/calendar/CalendarOverlap");
 
 export const routes = [
   {
@@ -27,6 +28,10 @@ export const routes = [
     path: "/",
     component: Home,
     children: [
+      {
+        path: "/overlap",
+        component: CalendarOverlap
+      },
       {
         path: "/reporting",
         component: Reporting

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -16,6 +16,7 @@ const LoggingIn = () => import("@/views/LoggingIn");
 const Onboarding = () => import("@/views/Onboarding");
 const FAQ = () => import("@/views/FAQ");
 const NotFound = () => import("@/views/NotFound");
+const Reporting = () => import("@/views/Reporting");
 
 export const routes = [
   {
@@ -26,6 +27,10 @@ export const routes = [
     path: "/",
     component: Home,
     children: [
+      {
+        path: "/reporting",
+        component: Reporting
+      },
       {
         path: "/404",
         name: "404",

--- a/src/services/contract.js
+++ b/src/services/contract.js
@@ -84,6 +84,9 @@ const ContractService = {
           reject(error);
         });
     });
+  },
+  lock: async function({ uuid, month, year }) {
+    return ApiService.post(`${BASE_URL}${uuid}/${month}/${year}/lock/`);
   }
 };
 

--- a/src/services/report.js
+++ b/src/services/report.js
@@ -1,18 +1,5 @@
 import ApiService from "@/services/api";
-
-function timedeltaToMinutes(timedelta) {
-  const splitTimedelta = timedelta.split(" ");
-  let days = 0;
-  let timeString = splitTimedelta[0];
-
-  if (splitTimedelta.length == 2) {
-    [days, timeString] = splitTimedelta;
-  }
-  // eslint-disable-next-line no-unused-vars
-  const [hours, minutes, seconds] = timeString.split(":");
-
-  return (parseInt(days) * 24 * 60 + parseInt(hours)) * 60 + parseInt(minutes);
-}
+import { timedeltaToMinutes } from "@/utils/time";
 
 function mapApiResponse(response) {
   return {

--- a/src/services/shift.js
+++ b/src/services/shift.js
@@ -10,7 +10,7 @@ function mapApiResponse(response) {
     type: response.type,
     note: response.note,
     tags: response.tags,
-    exported: response.was_exported,
+    locked: response.locked,
     reviewed: response.was_reviewed,
     created_at: new Date(response.created_at),
     modified_at: new Date(response.modified_at)

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -8,6 +8,23 @@ Number.prototype.pad = function(size) {
   return s;
 };
 
+export function timedeltaToMinutes(timedelta) {
+  const splitTimedelta = timedelta.split(" ");
+  let days = 0;
+  let timeString = splitTimedelta[0];
+
+  if (splitTimedelta.length == 2) {
+    [days, timeString] = splitTimedelta;
+  }
+  // eslint-disable-next-line no-unused-vars
+  const [hours, minutes, seconds] = timeString
+    .split(":")
+    .map(item => parseInt(item));
+  days = parseInt(days);
+
+  return (days * 24 + hours) * 60 + minutes;
+}
+
 export function minutesToHHMM(min, format) {
   min = Math.abs(min);
   const hours = Math.floor(min / 60).pad(2);

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -9,6 +9,7 @@ Number.prototype.pad = function(size) {
 };
 
 export function minutesToHHMM(min, format) {
+  min = Math.abs(min);
   const hours = Math.floor(min / 60).pad(2);
   const minutes = (min % 60).pad(2);
 

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -26,11 +26,15 @@ export function timedeltaToMinutes(timedelta) {
 }
 
 export function minutesToHHMM(min, format) {
+  const sign = min < 0 ? "-" : "";
+
   min = Math.abs(min);
   const hours = Math.floor(min / 60).pad(2);
   const minutes = (min % 60).pad(2);
 
-  return format === "hm" ? `${hours}h ${minutes}m` : `${hours}:${minutes}`;
+  return format === "hm"
+    ? `${sign}${hours}h ${minutes}m`
+    : `${sign}${hours}:${minutes}`;
 }
 
 export function startEndHours(date) {

--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -61,8 +61,11 @@
             <ReportCard
               :key="data.report.uuid"
               :report="data.report"
-              :exported="data.report.exported"
+              :exported="data.isCurrentMonthLocked"
               :is-lockable="!data.isCurrentMonthLocked"
+              :is-first-unlocked-month="data.firstUnlockedMonth === date"
+              :shifts="data.shifts"
+              :carryover="data.carryover()"
               @locked="refresh"
             ></ReportCard>
           </template>

--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -2,6 +2,11 @@
   <v-container>
     <v-row>
       <v-col cols="12">
+        <v-alert v-if="personnelNumberMissing" type="warning">
+          {{ $t("reports.personnelNumberMissing") }}
+        </v-alert>
+      </v-col>
+      <v-col cols="12">
         <SelectContractFilter
           :contracts="contracts"
           :selected-contract="selectedContract"
@@ -105,6 +110,9 @@ export default {
       const uuid = this.$route.params.contract;
 
       return this.contracts.find(contract => contract.uuid === uuid);
+    },
+    personnelNumberMissing() {
+      return !this.$store.state.user.personal_number;
     }
   },
   methods: {

--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -1,114 +1,118 @@
 <template>
-  <base-layout
-    alternative-portal-target="card-toolbar"
-    :card-elevation="$vuetify.breakpoint.smAndDown ? 0 : null"
-  >
-    <template v-slot:card-top>
-      <portal-target name="card-toolbar"></portal-target>
-    </template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <SelectContractFilter
+          :contracts="contracts"
+          :selected-contract="selectedContract"
+        />
+      </v-col>
 
-    <template v-slot:pre-toolbar-title="{ action }">
-      <v-app-bar-nav-icon
-        v-if="$vuetify.breakpoint.smAndDown"
-        icon
-        @click="action"
-      ></v-app-bar-nav-icon>
-    </template>
+      <v-card min-width="100%" :elevation="0">
+        <v-row class="mx-0">
+          <DataFilter
+            :date="date"
+            :contract="selectedContract"
+            @update="updateDate"
+          >
+            <template #default="{ data }">
+              <v-row justify="center">
+                <v-btn
+                  :disabled="!data.hasPrevMonth()"
+                  text
+                  @click="data.prevMonth"
+                >
+                  <v-icon>{{ icons.mdiChevronLeft }}</v-icon>
+                </v-btn>
 
-    <template v-slot:title>
-      {{ $tc("models.report", 2) }}
-    </template>
+                <v-menu
+                  v-model="dateMenu"
+                  :close-on-content-click="false"
+                  :nudge-right="40"
+                  transition="scale-transition"
+                  offset-y
+                  min-width="290px"
+                >
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn text v-bind="attrs" v-on="on">
+                      {{ date }}
+                    </v-btn>
+                  </template>
+                  <v-date-picker
+                    :value="date"
+                    :allowed-dates="data.months.allowedMonths"
+                    :min="data.months.min"
+                    :max="data.months.max"
+                    type="month"
+                    @input="updateDate($event)"
+                  ></v-date-picker>
+                </v-menu>
 
-    <template v-slot:content>
-      <DataFilter>
-        <template #default="{ data }">
-          <v-stepper v-model="step" vertical>
-            <v-stepper-step :complete="step > 1" step="1">
-              Select a month
-            </v-stepper-step>
+                <v-btn
+                  :disabled="!data.hasNextMonth()"
+                  text
+                  @click="data.nextMonth"
+                >
+                  <v-icon>{{ icons.mdiChevronRight }}</v-icon>
+                </v-btn>
+              </v-row>
 
-            <v-stepper-content step="1">
-              <v-date-picker
-                v-model="date"
-                :allowed-dates="data.allowedMonths"
-                :min="data.months.min"
-                :max="data.months.max"
-                :landscape="true"
-                type="month"
-              ></v-date-picker>
+              <v-row>
+                <DashboardConflicts :shifts="data.shifts" :month="data.date" />
+              </v-row>
 
-              <v-divider></v-divider>
-              <v-btn color="primary" @click="step = 2">Continue</v-btn>
-              <v-btn text>Cancel</v-btn>
-            </v-stepper-content>
-
-            <v-stepper-step :complete="step > 2" step="2">
-              Problem check
-              <small>Making sure everything is in order.</small>
-            </v-stepper-step>
-
-            <v-stepper-content step="2">
-              <DashboardConflicts :shifts="data.shifts" />
-
-              <v-divider></v-divider>
-              <v-btn color="primary" @click="step = 3">Continue</v-btn>
-              <v-btn text>Cancel</v-btn>
-            </v-stepper-content>
-
-            <v-stepper-step :complete="step > 3" step="3">
-              Export the Stundenzettel
-            </v-stepper-step>
-
-            <v-stepper-content step="3">
-              <ReportCard
-                :key="data.reports[0].uuid"
-                :report="data.reports[0]"
-                :exported="data.reports[0].exported"
-              ></ReportCard>
-
-              <v-divider></v-divider>
-              <v-btn color="primary" @click="step = 4">Continue</v-btn>
-              <v-btn text>Cancel</v-btn>
-            </v-stepper-content>
-
-            <v-stepper-step step="4">Finalize the report</v-stepper-step>
-            <v-stepper-content step="4">
-              <span>
-                Before exporting the next month, you need to finalize the
-                report. Warning: after finalizing the report, you will not be
-                able to edit any shifts of that month!
-              </span>
-
-              <v-btn @click="finalize">
-                Finalize
-              </v-btn>
-
-              <v-divider></v-divider>
-              <v-btn color="primary" @click="step = 1">Continue</v-btn>
-              <v-btn text>Cancel</v-btn>
-            </v-stepper-content>
-          </v-stepper>
-          {{ json(data) }}
-        </template>
-      </DataFilter>
-    </template>
-  </base-layout>
+              <v-row>
+                <ReportCard
+                  :key="data.report.uuid"
+                  :report="data.report"
+                  :exported="data.report.exported"
+                ></ReportCard>
+              </v-row>
+            </template>
+          </DataFilter>
+        </v-row>
+      </v-card>
+    </v-row>
+  </v-container>
 </template>
 
 <script>
+import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
+
 import DataFilter from "@/components/DataFilter";
 import DashboardConflicts from "@/components/DashboardConflicts";
+import SelectContractFilter from "@/components/SelectContractFilter";
 import ReportCard from "@/components/ReportCard";
 import { log } from "@/utils/log";
+import { mapGetters } from "vuex";
+
 export default {
   name: "Reporting",
-  components: { DataFilter, DashboardConflicts, ReportCard },
+  components: {
+    DataFilter,
+    DashboardConflicts,
+    ReportCard,
+    SelectContractFilter
+  },
   data: () => ({
-    allowedDates: ["2020-06", "2020-07"],
+    dateMenu: false,
     date: "2020-07",
-    step: 1
+    icons: { mdiChevronLeft, mdiChevronRight }
   }),
+  computed: {
+    ...mapGetters({
+      contracts: "contract/contracts"
+    }),
+    selectedContract() {
+      const uuid = this.$route.params.contract;
+
+      return this.contracts.find(contract => contract.uuid === uuid);
+    }
+  },
   methods: {
+    updateDate(value) {
+      this.date = value;
+    },
     json(data) {
       log(JSON.stringify(data, null, 2));
     },

--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -8,70 +8,66 @@
         />
       </v-col>
 
-      <v-card min-width="100%" :elevation="0">
-        <v-row class="mx-0">
-          <DataFilter
-            :date="date"
-            :contract="selectedContract"
-            @update="updateDate"
-          >
-            <template #default="{ data }">
-              <v-row justify="center">
-                <v-btn
-                  :disabled="!data.hasPrevMonth()"
-                  text
-                  @click="data.prevMonth"
-                >
-                  <v-icon>{{ icons.mdiChevronLeft }}</v-icon>
-                </v-btn>
+      <v-col>
+        <DataFilter
+          :date="date"
+          :contract="selectedContract"
+          @update="updateDate"
+        >
+          <template #default="{ data }">
+            <v-row justify="center">
+              <v-btn
+                :disabled="!data.hasPrevMonth()"
+                text
+                @click="data.prevMonth"
+              >
+                <v-icon>{{ icons.mdiChevronLeft }}</v-icon>
+              </v-btn>
 
-                <v-menu
-                  v-model="dateMenu"
-                  :close-on-content-click="false"
-                  :nudge-right="40"
-                  transition="scale-transition"
-                  offset-y
-                  min-width="290px"
-                >
-                  <template v-slot:activator="{ on, attrs }">
-                    <v-btn text v-bind="attrs" v-on="on">
-                      {{ date }}
-                    </v-btn>
-                  </template>
-                  <v-date-picker
-                    :value="date"
-                    :allowed-dates="data.months.allowedMonths"
-                    :min="data.months.min"
-                    :max="data.months.max"
-                    type="month"
-                    @input="updateDate($event)"
-                  ></v-date-picker>
-                </v-menu>
+              <v-menu
+                v-model="dateMenu"
+                :close-on-content-click="false"
+                :nudge-right="40"
+                transition="scale-transition"
+                offset-y
+                min-width="290px"
+              >
+                <template v-slot:activator="{ on, attrs }">
+                  <v-btn text v-bind="attrs" v-on="on">
+                    {{ date }}
+                  </v-btn>
+                </template>
+                <v-date-picker
+                  :value="date"
+                  :allowed-dates="data.months.allowedMonths"
+                  :min="data.months.min"
+                  :max="data.months.max"
+                  type="month"
+                  @input="updateDate($event)"
+                ></v-date-picker>
+              </v-menu>
 
-                <v-btn
-                  :disabled="!data.hasNextMonth()"
-                  text
-                  @click="data.nextMonth"
-                >
-                  <v-icon>{{ icons.mdiChevronRight }}</v-icon>
-                </v-btn>
-              </v-row>
+              <v-btn
+                :disabled="!data.hasNextMonth()"
+                text
+                @click="data.nextMonth"
+              >
+                <v-icon>{{ icons.mdiChevronRight }}</v-icon>
+              </v-btn>
+            </v-row>
 
-              <v-row>
-                <DashboardConflicts :shifts="data.shifts" :month="data.date" />
-              </v-row>
+            <DashboardConflicts :shifts="data.shifts" :month="data.date" />
 
-              <v-row>
-                <ReportCard
-                  :key="data.report.uuid"
-                  :report="data.report"
-                  :exported="data.report.exported"
-                ></ReportCard>
-              </v-row>
-            </template>
-          </DataFilter>
-        </v-row>
-      </v-card>
+            <ReportCard
+              :key="data.report.uuid"
+              :report="data.report"
+              :exported="data.report.exported"
+              :is-lockable="!data.isCurrentMonthLocked"
+              @locked="refresh"
+            ></ReportCard>
+          </template>
+        </DataFilter>
+      </v-col>
     </v-row>
   </v-container>
 </template>
@@ -83,7 +79,6 @@ import DataFilter from "@/components/DataFilter";
 import DashboardConflicts from "@/components/DashboardConflicts";
 import SelectContractFilter from "@/components/SelectContractFilter";
 import ReportCard from "@/components/ReportCard";
-import { log } from "@/utils/log";
 import { mapGetters } from "vuex";
 
 export default {
@@ -113,11 +108,12 @@ export default {
     updateDate(value) {
       this.date = value;
     },
-    json(data) {
-      log(JSON.stringify(data, null, 2));
-    },
-    finalize() {
-      alert("Das ist jetzt aber nicht final.");
+    async refresh() {
+      await Promise.all([
+        this.$store.dispatch("shift/queryShifts"),
+        this.$store.dispatch("contract/queryContracts"),
+        this.$store.dispatch("report/list")
+      ]);
     }
   }
 };

--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -1,0 +1,119 @@
+<template>
+  <base-layout
+    alternative-portal-target="card-toolbar"
+    :card-elevation="$vuetify.breakpoint.smAndDown ? 0 : null"
+  >
+    <template v-slot:card-top>
+      <portal-target name="card-toolbar"></portal-target>
+    </template>
+
+    <template v-slot:pre-toolbar-title="{ action }">
+      <v-app-bar-nav-icon
+        v-if="$vuetify.breakpoint.smAndDown"
+        icon
+        @click="action"
+      ></v-app-bar-nav-icon>
+    </template>
+
+    <template v-slot:title>
+      {{ $tc("models.report", 2) }}
+    </template>
+
+    <template v-slot:content>
+      <DataFilter>
+        <template #default="{ data }">
+          <v-stepper v-model="step" vertical>
+            <v-stepper-step :complete="step > 1" step="1">
+              Select a month
+            </v-stepper-step>
+
+            <v-stepper-content step="1">
+              <v-date-picker
+                v-model="date"
+                :allowed-dates="data.allowedMonths"
+                :min="data.months.min"
+                :max="data.months.max"
+                :landscape="true"
+                type="month"
+              ></v-date-picker>
+
+              <v-divider></v-divider>
+              <v-btn color="primary" @click="step = 2">Continue</v-btn>
+              <v-btn text>Cancel</v-btn>
+            </v-stepper-content>
+
+            <v-stepper-step :complete="step > 2" step="2">
+              Problem check
+              <small>Making sure everything is in order.</small>
+            </v-stepper-step>
+
+            <v-stepper-content step="2">
+              <DashboardConflicts :shifts="data.shifts" />
+
+              <v-divider></v-divider>
+              <v-btn color="primary" @click="step = 3">Continue</v-btn>
+              <v-btn text>Cancel</v-btn>
+            </v-stepper-content>
+
+            <v-stepper-step :complete="step > 3" step="3">
+              Export the Stundenzettel
+            </v-stepper-step>
+
+            <v-stepper-content step="3">
+              <ReportCard
+                :key="data.reports[0].uuid"
+                :report="data.reports[0]"
+                :exported="data.reports[0].exported"
+              ></ReportCard>
+
+              <v-divider></v-divider>
+              <v-btn color="primary" @click="step = 4">Continue</v-btn>
+              <v-btn text>Cancel</v-btn>
+            </v-stepper-content>
+
+            <v-stepper-step step="4">Finalize the report</v-stepper-step>
+            <v-stepper-content step="4">
+              <span>
+                Before exporting the next month, you need to finalize the
+                report. Warning: after finalizing the report, you will not be
+                able to edit any shifts of that month!
+              </span>
+
+              <v-btn @click="finalize">
+                Finalize
+              </v-btn>
+
+              <v-divider></v-divider>
+              <v-btn color="primary" @click="step = 1">Continue</v-btn>
+              <v-btn text>Cancel</v-btn>
+            </v-stepper-content>
+          </v-stepper>
+          {{ json(data) }}
+        </template>
+      </DataFilter>
+    </template>
+  </base-layout>
+</template>
+
+<script>
+import DataFilter from "@/components/DataFilter";
+import DashboardConflicts from "@/components/DashboardConflicts";
+import ReportCard from "@/components/ReportCard";
+export default {
+  name: "Reporting",
+  components: { DataFilter, DashboardConflicts, ReportCard },
+  data: () => ({
+    allowedDates: ["2020-06", "2020-07"],
+    date: "2020-07",
+    step: 1
+  }),
+  methods: {
+    json(data) {
+      console.log(JSON.stringify(data, null, 2));
+    },
+    finalize() {
+      alert("Das ist jetzt aber nicht final.");
+    }
+  }
+};
+</script>

--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -99,6 +99,7 @@
 import DataFilter from "@/components/DataFilter";
 import DashboardConflicts from "@/components/DashboardConflicts";
 import ReportCard from "@/components/ReportCard";
+import { log } from "@/utils/log";
 export default {
   name: "Reporting",
   components: { DataFilter, DashboardConflicts, ReportCard },
@@ -109,7 +110,7 @@ export default {
   }),
   methods: {
     json(data) {
-      console.log(JSON.stringify(data, null, 2));
+      log(JSON.stringify(data, null, 2));
     },
     finalize() {
       alert("Das ist jetzt aber nicht final.");

--- a/src/views/ViewReportList.vue
+++ b/src/views/ViewReportList.vue
@@ -125,7 +125,7 @@ export default {
       if (!(key in this.shiftsByMonth)) return false;
 
       const shifts = this.shiftsByMonth[key];
-      const exported = shifts.map(shift => shift.exported);
+      const exported = shifts.map(shift => shift.locked);
       return exported.every(x => x);
     }
   }

--- a/tests/unit/models/Contracts.spec.js
+++ b/tests/unit/models/Contracts.spec.js
@@ -13,7 +13,7 @@ describe("Contracts.js", () => {
       uuid: null,
       user: null,
       name: null,
-      hours: null,
+      worktime: null,
       date: date
     });
   });
@@ -23,33 +23,33 @@ describe("Contracts.js", () => {
       uuid: "1234",
       user: "user",
       name: "name",
-      hours: 40,
       date: date
     };
 
     const output = {
       ...data,
-      hours: "40:00"
+      worktime: "40:00"
     };
 
-    const obj = new Contract(data);
-    expect(obj).toEqual(output);
+    expect(new Contract({ ...data, minutes: 2400 })).toEqual(output);
   });
 
-  it("converts hours user input / API response back and forth correctly", () => {
-    const data = {
+  it("converts worktime user input / API response back and forth correctly", () => {
+    let data = {
       uuid: "1234",
       user: "user",
       name: "name",
-      hours: 40.5,
       date: date
     };
 
-    expect(new Contract(data)).toEqual({ ...data, hours: "40:30" });
-
-    expect(new Contract({ ...data, hours: 0.25 })).toEqual({
+    expect(new Contract({ ...data, minutes: 600 })).toEqual({
       ...data,
-      hours: "00:15"
+      worktime: "10:00"
+    });
+
+    expect(new Contract({ ...data, minutes: 50 })).toEqual({
+      ...data,
+      worktime: "00:50"
     });
   });
 

--- a/tests/unit/utils/time.spec.js
+++ b/tests/unit/utils/time.spec.js
@@ -1,4 +1,26 @@
-import { startEndHours } from "@/utils/time";
+import { startEndHours, timedeltaToMinutes } from "@/utils/time";
+
+describe("When handling a timedelta", () => {
+  it("converts '10:00:00' to 600 minutes", () => {
+    expect(timedeltaToMinutes("10:00:00")).toEqual(600);
+  });
+
+  it("converts '00:00:00' to 0 minutes", () => {
+    expect(timedeltaToMinutes("00:00:00")).toEqual(0);
+  });
+
+  it("converts '1 00:00:00' to 1440 minutes", () => {
+    expect(timedeltaToMinutes("1 00:00:00")).toEqual(1440);
+  });
+
+  it("converts '-1 16:00:00' to -480 minutes", () => {
+    expect(timedeltaToMinutes("-1 16:00:00")).toEqual(-480);
+  });
+
+  it("converts '-5 16:00:00' to -5820 minutes", () => {
+    expect(timedeltaToMinutes("-5 23:00:00")).toEqual(-5820);
+  });
+});
 
 describe("startEndHours()", () => {
   it("always return shift buffered one hour around current time", () => {


### PR DESCRIPTION
- Add new reporting view, remove old.
- Add new `CalendarOverlap` component to show shift overlaps and resolve them.
- Add new flow, where users must first lock the Report of a previous month, before they can lock the next one.


## To-Do

- [x] show a warning if `personnelNumber` is missing (Resolves #125)