### PR TITLE
Admin - Clock aus Sicht eines Nutzers benutzen.

### DIFF
--- a/src/components/AdminCheckoutUser.vue
+++ b/src/components/AdminCheckoutUser.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-card elevation="0">
+    <v-card-title>Select a UUID of a User to checkout</v-card-title>
+
+    <v-card-text>
+      <p>Select a User to get his data for support or debuggin purpose</p>
+
+      <v-form>
+        <v-text-field v-model="userUUID"></v-text-field>
+      </v-form>
+    </v-card-text>
+
+    <v-card-actions>
+      <v-btn color="primary" text @click="save">
+        {{ $t("actions.save") }}
+      </v-btn>
+      <v-btn color="alert" text @click="clear">
+        {{ $t("actions.delete") }}
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+import ApiService from "@/services/api.js";
+export default {
+  name: "AdminCheckoutUser",
+  data() {
+    return {
+      userUUID: ""
+    };
+  },
+  created() {
+    this.userUUID = this.$store.getters.checkoutUser;
+  },
+  methods: {
+    save() {
+      ApiService.setHeader("Checkoutuser", this.userUUID);
+      this.$store.commit("SET_CHECKOUT_USER", this.userUUID);
+    },
+    clear() {
+      ApiService.removeSingleHeader("Checkoutuser");
+      this.$store.commit("CLEAR_CHECKOUT_USER");
+    }
+  }
+};
+</script>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -29,6 +29,10 @@ const ApiService = {
     axios.defaults.headers.common = {};
   },
 
+  removeSingleHeader(header) {
+    delete axios.defaults.headers.common[header];
+  },
+
   get(resource, config = {}) {
     log("ApiService.get called");
     return axios.get(resource, config);

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -6,13 +6,15 @@ import { log } from "@/utils/log";
 const state = {
   accessToken: null,
   refreshToken: null,
-  refreshTokenPromise: null
+  refreshTokenPromise: null,
+  checkoutUser: "String"
 };
 
 const getters = {
   loggedIn: (state) => state.accessToken !== null,
   accessToken: (state) => state.accessToken,
-  refreshToken: (state) => state.refreshToken
+  refreshToken: (state) => state.refreshToken,
+  checkoutUser: (state) => state.checkoutUser
 };
 
 const actions = {
@@ -88,6 +90,12 @@ const mutations = {
   },
   SET_REFRESH_TOKEN_PROMISE(state, payload) {
     state.refreshTokenPromise = payload;
+  },
+  SET_CHECKOUT_USER(state, payload) {
+    state.checkoutUser = payload;
+  },
+  CLEAR_CHECKOUT_USER(state) {
+    state.checkoutUser = "";
   }
 };
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -41,6 +41,11 @@
           {{ $t("app.account") }}
         </v-tab>
 
+        <v-tab v-if="isSuperUser">
+          <v-icon left>{{ icons.mdiAccountRemove }}</v-icon>
+          Checkout User
+        </v-tab>
+
         <v-tab-item>
           <LanguageSettings />
         </v-tab-item>
@@ -55,6 +60,10 @@
 
         <v-tab-item>
           <DeleteAccount />
+        </v-tab-item>
+
+        <v-tab-item>
+          <AdminCheckoutUser />
         </v-tab-item>
       </v-tabs>
     </template>
@@ -74,6 +83,7 @@ import DeleteAccount from "@/components/DeleteAccount";
 import GDPR from "@/components/GDPR";
 import PersonnelNumberForm from "@/components/PersonnelNumberForm";
 import LanguageSettings from "@/components/LanguageSettings";
+import AdminCheckoutUser from "@/components/AdminCheckoutUser";
 
 export default {
   name: "Settings",
@@ -82,7 +92,13 @@ export default {
       title: this.$t("app.settings")
     };
   },
-  components: { DeleteAccount, GDPR, PersonnelNumberForm, LanguageSettings },
+  components: {
+    DeleteAccount,
+    GDPR,
+    PersonnelNumberForm,
+    LanguageSettings,
+    AdminCheckoutUser
+  },
   data: () => ({
     icons: {
       mdiFileAccount,
@@ -91,7 +107,13 @@ export default {
       mdiFormatSection,
       mdiWeb
     }
-  })
+  }),
+  computed: {
+    isSuperUser() {
+      console.log(this.$store.getters.user);
+      return this.$store.getters.user.is_superuser;
+    }
+  }
 };
 </script>
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -42,7 +42,7 @@
         </v-tab>
 
         <v-tab v-if="isSuperUser">
-          <v-icon left>{{ icons.mdiAccountRemove }}</v-icon>
+          <v-icon left>{{ icons.mdiAccountReactivate }}</v-icon>
           Checkout User
         </v-tab>
 
@@ -76,7 +76,8 @@ import {
   mdiBadgeAccountHorizontal,
   mdiAccountRemove,
   mdiFormatSection,
-  mdiWeb
+  mdiWeb,
+  mdiAccountReactivate
 } from "@mdi/js";
 
 import DeleteAccount from "@/components/DeleteAccount";
@@ -105,7 +106,8 @@ export default {
       mdiBadgeAccountHorizontal,
       mdiAccountRemove,
       mdiFormatSection,
-      mdiWeb
+      mdiWeb,
+      mdiAccountReactivate
     }
   }),
   computed: {


### PR DESCRIPTION
Um Support und Debugging zu erleichtern soll es Admins ermöglicht werden sich die Daten anderer Nutzer IN CLOCK SELBST ansehen zukönnen.

Dazu erstellen wir einen neuen DashboardDrawer Eintrag der es ermöglicht die UUID eines Users einzugeben.
Diese wird dann als custom Header bei jedem Request mitgeschickt. Das Backend muss demnach so angepasst werden, dass sofern ein Nutzer Admin UND dieser HEADER gesetzt ist auch die Daten des spezifizierten Users ausgibt.