### PR TITLE
Fix validations

### DIFF
--- a/src/components/FormDialog.vue
+++ b/src/components/FormDialog.vue
@@ -273,6 +273,9 @@ export default {
       if (!isAnArray) {
         entityToSave = [this.toSave];
       }
+      if (this.splitToSave !== null) {
+        entityToSave.push(this.splitToSave);
+      }
       const promises = [];
 
       try {

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -208,7 +208,8 @@ import {
   sufficientBreaktimeBetweenShifts,
   maxWorktimeExceeded,
   missingBreaktime,
-  maxShifttimeExceeded
+  maxShifttimeExceeded,
+  concatenatedShiftsTooLong
 } from "@/utils/shift";
 
 export default {
@@ -368,6 +369,12 @@ export default {
         differenceInMinutes(this.shift.date.end, this.shift.date.start)
       );
     },
+    concatenatedShiftsTooLong() {
+      return concatenatedShiftsTooLong(
+        this.shiftsOnSelectedDate.concat([]),
+        this.shift
+      );
+    },
     shiftIsOverlapping() {
       for (let shift of this.shiftsOnSelectedDate) {
         if (shift.uuid !== this.shift.uuid) {
@@ -455,6 +462,10 @@ export default {
 
       if (this.shiftTooLong && !this.trimBreaktime) {
         messages.push(this.$t("shifts.warnings.maxShifttimeExceeded"));
+      }
+
+      if (this.concatenatedShiftsTooLong) {
+        messages.push(this.$t("shifts.warnings.concatenatedShiftTooLong"));
       }
 
       if (this.shiftIsOverlapping) {

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -453,7 +453,7 @@ export default {
         messages.push(this.$t("shifts.warnings.maxWorktimeExceeded"));
       }
 
-      if (this.shiftTooLong) {
+      if (this.shiftTooLong && !this.trimBreaktime) {
         messages.push(this.$t("shifts.warnings.maxShifttimeExceeded"));
       }
 

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -367,6 +367,19 @@ export default {
         differenceInMinutes(this.shift.date.end, this.shift.date.start)
       );
     },
+    shiftIsOverlapping() {
+      for (let shift of this.shiftsOnSelectedDate) {
+        if (shift.uuid !== this.shift.uuid) {
+          return (
+            (parseISO(shift.date.start) <= this.shift.date.start &&
+              parseISO(shift.date.end) > this.shift.date.start) ||
+            (parseISO(shift.date.start) < this.shift.date.end &&
+              parseISO(shift.date.end) >= this.shift.date.end)
+          );
+        }
+      }
+      return false;
+    },
     valid() {
       if (
         isAfter(this.shift.date.start, this.shift.date.end) ||
@@ -440,6 +453,11 @@ export default {
 
       if (this.shiftTooLong) {
         messages.push(this.$t("shifts.warnings.maxShifttimeExceeded"));
+      }
+
+      console.log("this.shiftIsOverlapping: ", this.shiftIsOverlapping);
+      if (this.shiftIsOverlapping) {
+        messages.push(this.$t("shifts.warnings.shiftIsOverlapping"));
       }
 
       return messages;

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -80,7 +80,7 @@
           ></ClockCardAlert>
         </v-expand-transition>
         <v-expand-transition>
-          <v-row v-if="!sufficientBreaktime" align="center">
+          <v-row v-if="!sufficientBreaktime || shiftTooLong" align="center">
             <v-col cols="12" md="5" class="ma-0">
               <v-checkbox
                 v-model="trimBreaktime"
@@ -175,6 +175,8 @@ import { dateIsHoliday, localizedFormat } from "@/utils/date";
 
 import { mapGetters } from "vuex";
 import {
+  addMinutes,
+  differenceInMinutes,
   endOfDay,
   formatISO,
   isAfter,
@@ -183,7 +185,8 @@ import {
   isFuture,
   isSameDay,
   isWithinInterval,
-  parseISO
+  parseISO,
+  subMinutes
 } from "date-fns";
 import {
   coalescWorktimeAndBreaktime,
@@ -203,7 +206,8 @@ import ClockCardAlert from "@/components/ClockCardAlert";
 import {
   sufficientBreaktimeBetweenShifts,
   maxWorktimeExceeded,
-  missingBreaktime
+  missingBreaktime,
+  maxShifttimeExceeded
 } from "@/utils/shift";
 
 export default {
@@ -358,6 +362,11 @@ export default {
     worktimeTooLong() {
       return maxWorktimeExceeded(this.worktimeAndBreaktimeOnDate.worktime);
     },
+    shiftTooLong() {
+      return maxShifttimeExceeded(
+        differenceInMinutes(this.shift.date.end, this.shift.date.start)
+      );
+    },
     valid() {
       if (
         isAfter(this.shift.date.start, this.shift.date.end) ||
@@ -367,7 +376,8 @@ export default {
         (this.multipleRegularShiftsExistOnDate &&
           (this.shift.type.value === "vn" || this.shift.type.value === "sk")) ||
         (!this.sufficientBreaktime && !this.trimBreaktime) ||
-        this.worktimeTooLong
+        this.worktimeTooLong ||
+        (this.shiftTooLong && !this.trimBreaktime)
       )
         return false;
 
@@ -426,6 +436,10 @@ export default {
 
       if (this.worktimeTooLong) {
         messages.push(this.$t("shifts.warnings.maxWorktimeExceeded"));
+      }
+
+      if (this.shiftTooLong) {
+        messages.push(this.$t("shifts.warnings.maxShifttimeExceeded"));
       }
 
       return messages;

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -178,7 +178,6 @@ import { dateIsHoliday, localizedFormat } from "@/utils/date";
 
 import { mapGetters } from "vuex";
 import {
-  addMinutes,
   differenceInMinutes,
   endOfDay,
   formatISO,
@@ -188,8 +187,7 @@ import {
   isFuture,
   isSameDay,
   isWithinInterval,
-  parseISO,
-  subMinutes
+  parseISO
 } from "date-fns";
 import {
   coalescWorktimeAndBreaktime,

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -360,7 +360,10 @@ export default {
       return coalescWorktimeAndBreaktime(shifts);
     },
     sufficientBreaktime() {
-      return sufficientBreaktimeBetweenShifts(this.worktimeAndBreaktimeOnDate);
+      return sufficientBreaktimeBetweenShifts(
+        this.shiftsOnSelectedDate.concat([]),
+        this.shift
+      );
     },
     worktimeTooLong() {
       return maxWorktimeExceeded(this.worktimeAndBreaktimeOnDate.worktime);
@@ -393,7 +396,8 @@ export default {
           (this.shift.type.value === "vn" || this.shift.type.value === "sk")) ||
         (!this.sufficientBreaktime && !this.trimBreaktime) ||
         this.worktimeTooLong ||
-        (this.shiftTooLong && !this.trimBreaktime)
+        (this.shiftTooLong && !this.trimBreaktime) ||
+        this.shiftIsOverlapping
       )
         return false;
 

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -393,7 +393,8 @@ export default {
           (this.shift.type.value === "vn" || this.shift.type.value === "sk")) ||
         (!this.sufficientBreaktime && !this.trimBreaktime) ||
         this.worktimeTooLong ||
-        (this.shiftTooLong && !this.trimBreaktime)
+        (this.shiftTooLong && !this.trimBreaktime) ||
+        this.shiftIsOverlapping
       )
         return false;
 

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -360,10 +360,7 @@ export default {
       return coalescWorktimeAndBreaktime(shifts);
     },
     sufficientBreaktime() {
-      return sufficientBreaktimeBetweenShifts(
-        this.shiftsOnSelectedDate.concat([]),
-        this.shift
-      );
+      return sufficientBreaktimeBetweenShifts(this.worktimeAndBreaktimeOnDate);
     },
     worktimeTooLong() {
       return maxWorktimeExceeded(this.worktimeAndBreaktimeOnDate.worktime);
@@ -396,8 +393,7 @@ export default {
           (this.shift.type.value === "vn" || this.shift.type.value === "sk")) ||
         (!this.sufficientBreaktime && !this.trimBreaktime) ||
         this.worktimeTooLong ||
-        (this.shiftTooLong && !this.trimBreaktime) ||
-        this.shiftIsOverlapping
+        (this.shiftTooLong && !this.trimBreaktime)
       )
         return false;
 

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -79,6 +79,9 @@
             :type="alertType"
           ></ClockCardAlert>
         </v-expand-transition>
+        <router-link v-if="messages.length !== 0" to="/faq">
+          {{ $t("shifts.warnings.faqLinking") }}
+        </router-link>
         <v-expand-transition>
           <v-row v-if="!sufficientBreaktime || shiftTooLong" align="center">
             <v-col cols="12" md="5" class="ma-0">
@@ -455,7 +458,6 @@ export default {
         messages.push(this.$t("shifts.warnings.maxShifttimeExceeded"));
       }
 
-      console.log("this.shiftIsOverlapping: ", this.shiftIsOverlapping);
       if (this.shiftIsOverlapping) {
         messages.push(this.$t("shifts.warnings.shiftIsOverlapping"));
       }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -475,7 +475,8 @@
       "insufficientBreaktime": "Ab einer Arbeitszeit von 6h müssen mindestens 30 Minuten, ab 9h mindestens 45 Minuten Pause eingelegt werden. ( Arbeitszeit {worktime}h, Pause {breaktime}h)",
       "maxWorktimeExceeded": "Du hast die maximale tägliche Arbeiszeit von 10h überschritten.",
       "maxShifttimeExceeded": "Diese Schicht überschreitet die maximal Schichtlänge von 6h.",
-      "shiftIsOverlapping": "Diese Schicht überschneidet sich mit bereits bestehenden Schichten."
+      "shiftIsOverlapping": "Diese Schicht überschneidet sich mit bereits bestehenden Schichten.",
+      "faqLinking": "Für weitere Informationen zu den angezeigten Fehlermeldungen bitte in in die FAQs schauen."
     }
   },
   "snackbar": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -476,6 +476,7 @@
       "maxWorktimeExceeded": "Du hast die maximale tägliche Arbeiszeit von 10h überschritten.",
       "maxShifttimeExceeded": "Diese Schicht überschreitet die maximal Schichtlänge von 6h.",
       "shiftIsOverlapping": "Diese Schicht überschneidet sich mit bereits bestehenden Schichten.",
+      "concatenatedShiftTooLong": "Diese Schicht ist mit anderen Schichten verbunden und diese sind in Summe zu lang (max 6h).",
       "faqLinking": "Für weitere Informationen zu den angezeigten Fehlermeldungen bitte in in die FAQs schauen."
     }
   },

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -472,8 +472,9 @@
       "selectedDateIsHoliday": "Das ausgewählte Datum ist ein Feiertag. Du kannst hier nur Schichten vom Typ \"Feiertag\" clocken.",
       "sickOrVacationShiftExists": "An diesem Datum existiert bereits eine Schicht vom Typ {shiftType}. Du kannst an diesem Tag nur noch Schichten von diesem Typ anlegen.",
       "noSickOrVacationWithRegularShift": "An diesem Datum existiert bereits eine normale Schicht. Du musst diese löschen oder deren Typ ändern bevor du eine Schicht vom Typ {shiftType} anlegen kannst.",
-      "insufficientBreaktime": "An diesem Datum existieren Schichten von {worktime}h und Pausen von {pause}h. Laut §4 ArbzG müssen ab einer Arbeitszeit von 6h mindestens 30 Minuten, nach 9h mindestens 45 Minuten Pause (in Summe) eingelegt werden.",
-      "maxWorktimeExceeded": "Du hast die maximale tägliche Arbeiszeit von 10h überschritten."
+      "insufficientBreaktime": "Ab einer Arbeitszeit von 6h müssen mindestens 30 Minuten, ab 9h mindestens 45 Minuten Pause eingelegt werden. ( Arbeitszeit {worktime}h, Pause {breaktime}h)",
+      "maxWorktimeExceeded": "Du hast die maximale tägliche Arbeiszeit von 10h überschritten.",
+      "maxShifttimeExceeded": "Diese Schicht überschreitet die maximal Schichtlänge von 6h."
     }
   },
   "snackbar": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -474,7 +474,8 @@
       "noSickOrVacationWithRegularShift": "An diesem Datum existiert bereits eine normale Schicht. Du musst diese löschen oder deren Typ ändern bevor du eine Schicht vom Typ {shiftType} anlegen kannst.",
       "insufficientBreaktime": "Ab einer Arbeitszeit von 6h müssen mindestens 30 Minuten, ab 9h mindestens 45 Minuten Pause eingelegt werden. ( Arbeitszeit {worktime}h, Pause {breaktime}h)",
       "maxWorktimeExceeded": "Du hast die maximale tägliche Arbeiszeit von 10h überschritten.",
-      "maxShifttimeExceeded": "Diese Schicht überschreitet die maximal Schichtlänge von 6h."
+      "maxShifttimeExceeded": "Diese Schicht überschreitet die maximal Schichtlänge von 6h.",
+      "shiftIsOverlapping": "Diese Schicht überschneidet sich mit bereits bestehenden Schichten."
     }
   },
   "snackbar": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -475,7 +475,8 @@
       "insufficientBreaktime": "There are shifts of {worktime}h with breaks of {breaktime}h on this date. According to §4 ArbzG, the work shall be interrupted by breaks of 30 minutes for a shift over 6h, and 45 minutes for a shift over 9h (in all).",
       "maxWorktimeExceeded": "You exceeded your maximum daily worktime of 10h.",
       "maxShifttimeExceeded": "This shift exceeds the maximum shift length of 6h.",
-      "shiftIsOverlapping": "This Shift overlaps with another already existing shift."
+      "shiftIsOverlapping": "This Shift overlaps with another already existing shift.",
+      "faqLinking": "For further information on the displayed error messages please check the FAQ."
     }
   },
   "snackbar": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -473,7 +473,8 @@
       "sickOrVacationShiftExists": "There are other shifts of type {shiftType} on this date. You can only create shifts of the same type.",
       "noSickOrVacationWithRegularShift": "There is already a normal shift on this date. Please delete the shift or change its type before creating a shift of type {shiftType}.",
       "insufficientBreaktime": "There are shifts of {worktime}h with breaks of {breaktime}h on this date. According to §4 ArbzG, the work shall be interrupted by breaks of 30 minutes for a shift over 6h, and 45 minutes for a shift over 9h (in all).",
-      "maxWorktimeExceeded": "You exceeded your maximum daily worktime of 10h."
+      "maxWorktimeExceeded": "You exceeded your maximum daily worktime of 10h.",
+      "maxShifttimeExceeded": "This shift exceeds the maximum shift length of 6h."
     }
   },
   "snackbar": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -474,7 +474,8 @@
       "noSickOrVacationWithRegularShift": "There is already a normal shift on this date. Please delete the shift or change its type before creating a shift of type {shiftType}.",
       "insufficientBreaktime": "There are shifts of {worktime}h with breaks of {breaktime}h on this date. According to §4 ArbzG, the work shall be interrupted by breaks of 30 minutes for a shift over 6h, and 45 minutes for a shift over 9h (in all).",
       "maxWorktimeExceeded": "You exceeded your maximum daily worktime of 10h.",
-      "maxShifttimeExceeded": "This shift exceeds the maximum shift length of 6h."
+      "maxShifttimeExceeded": "This shift exceeds the maximum shift length of 6h.",
+      "shiftIsOverlapping": "This Shift overlaps with another already existing shift."
     }
   },
   "snackbar": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -476,6 +476,7 @@
       "maxWorktimeExceeded": "You exceeded your maximum daily worktime of 10h.",
       "maxShifttimeExceeded": "This shift exceeds the maximum shift length of 6h.",
       "shiftIsOverlapping": "This Shift overlaps with another already existing shift.",
+      "concatenatedShiftTooLong": "This shift is concatenated with other shifts and they are in total to long (max 6h).",
       "faqLinking": "For further information on the displayed error messages please check the FAQ."
     }
   },

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -6,7 +6,9 @@ import {
   subWeeks,
   addMonths,
   subMonths,
-  format
+  format,
+  addMinutes,
+  subMinutes
 } from "date-fns";
 
 import Holidays from "date-holidays";
@@ -45,7 +47,9 @@ export const dateOperations = {
   addWeeks: addWeeks,
   subWeeks: subWeeks,
   addMonths: addMonths,
-  subMonths: subMonths
+  subMonths: subMonths,
+  addMinutes: addMinutes,
+  subMinutes: subMinutes
 };
 
 export const getRouterProps = (type, date = new Date()) => {

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -55,3 +55,7 @@ export function missingBreaktime({ worktime, breaktime }) {
 export function maxWorktimeExceeded(worktime) {
   return worktime > 10 * 60;
 }
+
+export function maxShifttimeExceeded(shifttime) {
+  return shifttime > 6 * 60;
+}

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -38,9 +38,11 @@ export function getOverlappingShifts(shifts) {
   return matches;
 }
 
-export function sufficientBreaktimeBetweenShifts(shifts, newShift) {
-  let validator = new newShiftCutter(shifts, newShift);
-  return validator.validateSufficientBreaks();
+export function sufficientBreaktimeBetweenShifts({ worktime, breaktime }) {
+  if (worktime > 9 * 60 && breaktime < 45) {
+    return false;
+  }
+  return !(worktime > 6 * 60 && breaktime < 30);
 }
 
 export function missingBreaktime({ worktime, breaktime }) {
@@ -52,114 +54,4 @@ export function missingBreaktime({ worktime, breaktime }) {
 
 export function maxWorktimeExceeded(worktime) {
   return worktime > 10 * 60;
-}
-
-export function maxShifttimeExceeded(shifttime) {
-  return shifttime > 6 * 60;
-}
-
-export class newShiftCutter {
-  new_shift_uuid;
-  shifts;
-
-  constructor(old_shifts, new_shift) {
-    this.new_shift_uuid = new_shift.uuid;
-    this.shifts = old_shifts;
-    if (!Array.isArray(old_shifts)) {
-      this.shifts.push(old_shifts);
-    }
-    if (!this.shifts.find((shift) => shift.uuid === this.new_shift_uuid)) {
-      let new_shift_local = new_shift.clone();
-      new_shift_local.date.start = localizedFormat(
-        new_shift_local.date.start,
-        "yyyy-MM-dd HH:mm:ssXXX",
-        {
-          locale: { localize: "en" }
-        }
-      );
-      new_shift_local.date.end = localizedFormat(
-        new_shift_local.date.end,
-        "yyyy-MM-dd HH:mm:ssXXX",
-        {
-          locale: { localize: "en" }
-        }
-      );
-      new_shift_local.uuid = "000";
-      this.new_shift_uuid = "000";
-      this.shifts.push(new_shift_local);
-    }
-    this.shifts = this.#privateSortShifts();
-  }
-
-  #getLastConcatenatedIndex(startIndex, directionRight) {
-    if (directionRight) {
-      // lets go to the right
-      if (this.shifts.length === 1 || startIndex === this.shifts.length - 1)
-        return startIndex;
-      else {
-        for (let i = Number(startIndex); i < this.shifts.length - 1; i++) {
-          if (this.shifts[i].date.end !== this.shifts[i + 1].date.start)
-            return i;
-        }
-        return this.shifts.length - 1;
-      }
-    } else {
-      //lets go to the left
-      if (startIndex === 0 || this.shifts.length === 1) return startIndex;
-      else {
-        for (let i = Number(startIndex); i > 0; i--) {
-          if (this.shifts[i].date.start !== this.shifts[i - 1].date.end)
-            return i;
-        }
-        return 0;
-      }
-    }
-  }
-
-  #privateSortShifts() {
-    // todo: delete redundancy when refactor data filter is deployed
-    return this.shifts.sort(
-      (a, b) => parseISO(a.date.start) - parseISO(b.date.start)
-    );
-  }
-
-  validateSufficientBreaks() {
-    let inTotalWorkBreakTime = coalescWorktimeAndBreaktime(this.shifts);
-    let newShiftIndex = this.shifts.findIndex(
-      (shift) => shift.uuid === this.new_shift_uuid
-    );
-    let leftSideWithNewShiftWorkBreak = coalescWorktimeAndBreaktime(
-      this.shifts.slice(0, newShiftIndex + 1)
-    );
-    let rightSideWithNewShiftWorkBreak = coalescWorktimeAndBreaktime(
-      this.shifts.slice(newShiftIndex, this.shifts.length)
-    );
-    let concatenatedRightShiftsWorkBreak = coalescWorktimeAndBreaktime(
-      this.shifts.slice(
-        newShiftIndex,
-        this.#getLastConcatenatedIndex(newShiftIndex, true) + 1
-      )
-    );
-    let concatenatedLeftShiftsWorkBreak = coalescWorktimeAndBreaktime(
-      this.shifts.slice(
-        this.#getLastConcatenatedIndex(newShiftIndex, false),
-        newShiftIndex + 1
-      )
-    );
-    if (
-      (inTotalWorkBreakTime.worktime > 9 * 60 &&
-        inTotalWorkBreakTime.breaktime < 45) ||
-      (inTotalWorkBreakTime.worktime > 6 * 60 &&
-        inTotalWorkBreakTime.worktime < 9 * 60 &&
-        inTotalWorkBreakTime.breaktime < 30) ||
-      (leftSideWithNewShiftWorkBreak.breaktime === 0 &&
-        leftSideWithNewShiftWorkBreak.worktime > 6 * 60) ||
-      (rightSideWithNewShiftWorkBreak.breaktime === 0 &&
-        rightSideWithNewShiftWorkBreak.worktime > 6 * 60) ||
-      concatenatedRightShiftsWorkBreak.worktime > 6 * 60 ||
-      concatenatedLeftShiftsWorkBreak.worktime > 6 * 60
-    )
-      return false;
-    return true;
-  }
 }

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -1,5 +1,9 @@
 import { Shift } from "@/models/ShiftModel";
-import { areIntervalsOverlapping, parseISO } from "date-fns";
+import {
+  areIntervalsOverlapping,
+  differenceInMinutes,
+  parseISO
+} from "date-fns";
 import { localizedFormat } from "@/utils/date";
 
 function prepare({ start, end }) {

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -1,6 +1,7 @@
 import { Shift } from "@/models/ShiftModel";
-import { areIntervalsOverlapping, parseISO } from "date-fns";
+import { areIntervalsOverlapping, isEqual, parseISO } from "date-fns";
 import { localizedFormat } from "@/utils/date";
+import { coalescWorktimeAndBreaktime } from "@/utils/time";
 
 function prepare({ start, end }) {
   return {
@@ -41,6 +42,11 @@ export function sufficientBreaktimeBetweenShifts({ worktime, breaktime }) {
   return !(worktime > 6 * 60 && breaktime < 30);
 }
 
+export function concatenatedShiftsTooLong(shifts, newShift) {
+  let validator = new newShiftValidator(shifts, newShift);
+  return validator.validateSufficientBreaks();
+}
+
 export function missingBreaktime({ worktime, breaktime }) {
   if (worktime >= 9 * 60) {
     return 45 - breaktime;
@@ -54,4 +60,113 @@ export function maxWorktimeExceeded(worktime) {
 
 export function maxShifttimeExceeded(shifttime) {
   return shifttime > 6 * 60;
+}
+
+export class newShiftValidator {
+  new_shift_uuid;
+  shifts;
+
+  constructor(old_shifts, new_shift) {
+    this.new_shift_uuid = new_shift.uuid;
+    this.shifts = old_shifts;
+    if (!Array.isArray(old_shifts)) {
+      this.shifts.push(old_shifts);
+    }
+    if (!this.shifts.find((shift) => shift.uuid === this.new_shift_uuid)) {
+      let new_shift_local = new_shift.clone();
+      new_shift_local.date.start = localizedFormat(
+        new_shift_local.date.start,
+        "yyyy-MM-dd HH:mm:ssXXX",
+        {
+          locale: { localize: "en" }
+        }
+      );
+      new_shift_local.date.end = localizedFormat(
+        new_shift_local.date.end,
+        "yyyy-MM-dd HH:mm:ssXXX",
+        {
+          locale: { localize: "en" }
+        }
+      );
+      new_shift_local.uuid = "000";
+      this.new_shift_uuid = "000";
+      this.shifts.push(new_shift_local);
+    }
+    this.shifts = this.#privateSortShifts();
+  }
+
+  #getLastConcatenatedIndex(startIndex, directionRight) {
+    if (directionRight) {
+      // lets go to the right
+      if (this.shifts.length === 1 || startIndex === this.shifts.length - 1)
+        return startIndex;
+      else {
+        for (let i = Number(startIndex); i < this.shifts.length - 1; i++) {
+          if (
+            !isEqual(
+              parseISO(this.shifts[i].date.end),
+              parseISO(this.shifts[i + 1].date.start)
+            )
+          )
+            return i;
+        }
+        return this.shifts.length - 1;
+      }
+    } else {
+      //lets go to the left
+      if (startIndex === 0 || this.shifts.length === 1) return startIndex;
+      else {
+        for (let i = Number(startIndex); i > 0; i--) {
+          if (
+            !isEqual(
+              parseISO(this.shifts[i].date.start),
+              parseISO(this.shifts[i - 1].date.end)
+            )
+          )
+            return i;
+        }
+        return 0;
+      }
+    }
+  }
+
+  #privateSortShifts() {
+    // todo: delete redundancy when refactor data filter is deployed
+    return this.shifts.sort(
+      (a, b) => parseISO(a.date.start) - parseISO(b.date.start)
+    );
+  }
+
+  validateSufficientBreaks() {
+    // let inTotalWorkBreakTime = coalescWorktimeAndBreaktime(this.shifts);
+    let newShiftIndex = this.shifts.findIndex(
+      (shift) => shift.uuid === this.new_shift_uuid
+    );
+    let leftSideWithNewShiftWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(0, newShiftIndex + 1)
+    );
+    let rightSideWithNewShiftWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(newShiftIndex, this.shifts.length)
+    );
+    let concatenatedRightShiftsWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(
+        newShiftIndex,
+        this.#getLastConcatenatedIndex(newShiftIndex, true) + 1
+      )
+    );
+    let concatenatedLeftShiftsWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(
+        this.#getLastConcatenatedIndex(newShiftIndex, false),
+        newShiftIndex + 1
+      )
+    );
+    return (
+      (leftSideWithNewShiftWorkBreak.breaktime === 0 &&
+        leftSideWithNewShiftWorkBreak.worktime > 6 * 60) ||
+      (rightSideWithNewShiftWorkBreak.breaktime === 0 &&
+        rightSideWithNewShiftWorkBreak.worktime > 6 * 60) ||
+      concatenatedRightShiftsWorkBreak.worktime > 6 * 60 ||
+      concatenatedLeftShiftsWorkBreak.worktime > 6 * 60
+    );
+  }
 }

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -1,9 +1,5 @@
 import { Shift } from "@/models/ShiftModel";
-import {
-  areIntervalsOverlapping,
-  differenceInMinutes,
-  parseISO
-} from "date-fns";
+import { areIntervalsOverlapping, parseISO } from "date-fns";
 import { localizedFormat } from "@/utils/date";
 
 function prepare({ start, end }) {

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -38,11 +38,9 @@ export function getOverlappingShifts(shifts) {
   return matches;
 }
 
-export function sufficientBreaktimeBetweenShifts({ worktime, breaktime }) {
-  if (worktime > 9 * 60 && breaktime < 45) {
-    return false;
-  }
-  return !(worktime > 6 * 60 && breaktime < 30);
+export function sufficientBreaktimeBetweenShifts(shifts, newShift) {
+  let validator = new newShiftCutter(shifts, newShift);
+  return validator.validateSufficientBreaks();
 }
 
 export function missingBreaktime({ worktime, breaktime }) {
@@ -54,4 +52,114 @@ export function missingBreaktime({ worktime, breaktime }) {
 
 export function maxWorktimeExceeded(worktime) {
   return worktime > 10 * 60;
+}
+
+export function maxShifttimeExceeded(shifttime) {
+  return shifttime > 6 * 60;
+}
+
+export class newShiftCutter {
+  new_shift_uuid;
+  shifts;
+
+  constructor(old_shifts, new_shift) {
+    this.new_shift_uuid = new_shift.uuid;
+    this.shifts = old_shifts;
+    if (!Array.isArray(old_shifts)) {
+      this.shifts.push(old_shifts);
+    }
+    if (!this.shifts.find((shift) => shift.uuid === this.new_shift_uuid)) {
+      let new_shift_local = new_shift.clone();
+      new_shift_local.date.start = localizedFormat(
+        new_shift_local.date.start,
+        "yyyy-MM-dd HH:mm:ssXXX",
+        {
+          locale: { localize: "en" }
+        }
+      );
+      new_shift_local.date.end = localizedFormat(
+        new_shift_local.date.end,
+        "yyyy-MM-dd HH:mm:ssXXX",
+        {
+          locale: { localize: "en" }
+        }
+      );
+      new_shift_local.uuid = "000";
+      this.new_shift_uuid = "000";
+      this.shifts.push(new_shift_local);
+    }
+    this.shifts = this.#privateSortShifts();
+  }
+
+  #getLastConcatenatedIndex(startIndex, directionRight) {
+    if (directionRight) {
+      // lets go to the right
+      if (this.shifts.length === 1 || startIndex === this.shifts.length - 1)
+        return startIndex;
+      else {
+        for (let i = Number(startIndex); i < this.shifts.length - 1; i++) {
+          if (this.shifts[i].date.end !== this.shifts[i + 1].date.start)
+            return i;
+        }
+        return this.shifts.length - 1;
+      }
+    } else {
+      //lets go to the left
+      if (startIndex === 0 || this.shifts.length === 1) return startIndex;
+      else {
+        for (let i = Number(startIndex); i > 0; i--) {
+          if (this.shifts[i].date.start !== this.shifts[i - 1].date.end)
+            return i;
+        }
+        return 0;
+      }
+    }
+  }
+
+  #privateSortShifts() {
+    // todo: delete redundancy when refactor data filter is deployed
+    return this.shifts.sort(
+      (a, b) => parseISO(a.date.start) - parseISO(b.date.start)
+    );
+  }
+
+  validateSufficientBreaks() {
+    let inTotalWorkBreakTime = coalescWorktimeAndBreaktime(this.shifts);
+    let newShiftIndex = this.shifts.findIndex(
+      (shift) => shift.uuid === this.new_shift_uuid
+    );
+    let leftSideWithNewShiftWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(0, newShiftIndex + 1)
+    );
+    let rightSideWithNewShiftWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(newShiftIndex, this.shifts.length)
+    );
+    let concatenatedRightShiftsWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(
+        newShiftIndex,
+        this.#getLastConcatenatedIndex(newShiftIndex, true) + 1
+      )
+    );
+    let concatenatedLeftShiftsWorkBreak = coalescWorktimeAndBreaktime(
+      this.shifts.slice(
+        this.#getLastConcatenatedIndex(newShiftIndex, false),
+        newShiftIndex + 1
+      )
+    );
+    if (
+      (inTotalWorkBreakTime.worktime > 9 * 60 &&
+        inTotalWorkBreakTime.breaktime < 45) ||
+      (inTotalWorkBreakTime.worktime > 6 * 60 &&
+        inTotalWorkBreakTime.worktime < 9 * 60 &&
+        inTotalWorkBreakTime.breaktime < 30) ||
+      (leftSideWithNewShiftWorkBreak.breaktime === 0 &&
+        leftSideWithNewShiftWorkBreak.worktime > 6 * 60) ||
+      (rightSideWithNewShiftWorkBreak.breaktime === 0 &&
+        rightSideWithNewShiftWorkBreak.worktime > 6 * 60) ||
+      concatenatedRightShiftsWorkBreak.worktime > 6 * 60 ||
+      concatenatedLeftShiftsWorkBreak.worktime > 6 * 60
+    )
+      return false;
+    return true;
+  }
 }


### PR DESCRIPTION
Wie besprochen alle Validations aus  #356 in einem gesonderten PR.

Es gibt ein GUI-Problem, dass ich irgendwie nicht finde @chgad vllt siehst du, was ich übersehe:
Beim Anwählen der Checkbox zum Shift Splitting verschwindet die Meldung _"Diese Schicht überschreitet die maximal Schichtlänge von 6h."_ nicht. Gewünschtes Verhalten wäre wie bei Meldung _"Ab einer Arbeitszeit von 6h müssen mindestens 30 Minuten, ab 9h mindestens 45 Minuten Pause eingelegt werden. (Arbeitszeit 08:00h, Pause 00:00h) "_, dass die Meldung nach dem Anwählen der Schicht teilen Chekbox wieder verschwindet.

Folgende Validations sind umgesetzt:
- [x] shiftIsOverlapping
- [x] shiftTooLong: `shifttime >= 6h`
- [x] worktimeTooLong: `worktime <= 10h`
- [x] sufficientBreaktime: bei `worktime > 9h breaktime >= 45min` bzw `worktime > 6h and <= 9h breaktiem >= 30min`
- [x] concatenated Shifts <= 6h max
--> Das könnte der aktuelle ShiftCutter zu einen nicht umsetzen, zum andern hatte ich dies als Methode der Klasse newShiftCutter implementiert, die es im hiesigen Branch nicht gibt.