### PR TITLE
ShiftRepeater validate shifts and exclude collision with other shifts or FKUS

### DIFF
--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -180,7 +180,6 @@ import { mapGetters } from "vuex";
 import {
   differenceInMinutes,
   endOfDay,
-  formatISO,
   isAfter,
   isBefore,
   isEqual,
@@ -189,11 +188,7 @@ import {
   isWithinInterval,
   parseISO
 } from "date-fns";
-import {
-  coalescWorktimeAndBreaktime,
-  minutesToHHMM,
-  startEndHours
-} from "@/utils/time";
+import { minutesToHHMM, startEndHours } from "@/utils/time";
 import contractValidMixin from "@/mixins/contractValid";
 
 import {
@@ -211,7 +206,8 @@ import {
   maxShifttimeExceeded,
   concatenatedShiftsTooLong,
   getContractShifts,
-  getShiftsOnSpecificDate
+  getShiftsOnSpecificDate,
+  getWorktimeAndBreaktimeOnDate
 } from "@/utils/shift";
 
 export default {
@@ -338,23 +334,10 @@ export default {
       );
     },
     worktimeAndBreaktimeOnDate() {
-      const formattedDate = {
-        start: formatISO(this.shift.date.start),
-        end: formatISO(this.shift.date.end)
-      };
-      // Copy Array
-      let shifts = this.shiftsOnSelectedDate.concat([]);
-      const indexOfShift = shifts.findIndex(
-        (shift) => shift.uuid === this.uuid
+      return getWorktimeAndBreaktimeOnDate(
+        this.shift.date,
+        this.shift.contract
       );
-      if (indexOfShift === -1) {
-        return coalescWorktimeAndBreaktime(
-          shifts.concat([{ date: formattedDate }]) // this is a Hack, only passing an object with a date key.
-        );
-      }
-      // Update the shift's date to current date
-      shifts[indexOfShift].date = formattedDate;
-      return coalescWorktimeAndBreaktime(shifts);
     },
     sufficientBreaktime() {
       return sufficientBreaktimeBetweenShifts(this.worktimeAndBreaktimeOnDate);

--- a/src/components/shifts/ShiftForm.vue
+++ b/src/components/shifts/ShiftForm.vue
@@ -209,7 +209,9 @@ import {
   maxWorktimeExceeded,
   missingBreaktime,
   maxShifttimeExceeded,
-  concatenatedShiftsTooLong
+  concatenatedShiftsTooLong,
+  getContractShifts,
+  getShiftsOnSpecificDate
 } from "@/utils/shift";
 
 export default {
@@ -317,14 +319,10 @@ export default {
       );
     },
     contractShifts() {
-      return this.$store.getters["shift/shifts"].filter((shift) => {
-        return shift.contract === this.shift.contract;
-      });
+      return getContractShifts(this.shift.contract);
     },
     shiftsOnSelectedDate() {
-      return this.contractShifts.filter((shift) => {
-        return isSameDay(parseISO(shift.date.start), this.shift.date.start);
-      });
+      return getShiftsOnSpecificDate(this.shift.date.start, this.contract);
     },
     sickOrVacationShifts() {
       if (this.shift === null) return [];

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -9,6 +9,7 @@ import {
 import store from "@/store";
 import { localizedFormat } from "@/utils/date";
 import { coalescWorktimeAndBreaktime } from "@/utils/time";
+import shift from "@/store/modules/shift";
 
 function prepare({ start, end }) {
   return {
@@ -47,6 +48,21 @@ export function getWorktimeAndBreaktimeOnDate(shiftDate, contract) {
   // Update the shift's date to current date
   shifts[indexOfShift].date = formattedDate;
   return coalescWorktimeAndBreaktime(shifts);
+}
+
+export function isSickOrVactionShiftOnSpecificDate(specificDate, contract) {
+  return isSickOrVactionShiftInShifts(
+    getShiftsOnSpecificDate(specificDate, contract)
+  );
+}
+
+export function isSickOrVactionShiftInShifts(shifts) {
+  for (let shift of shifts) {
+    if (shift.type.value === "vn" || shift.type.value === "sk") {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function datesGroupByComponent(dates, token) {

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -3,6 +3,7 @@ import {
   areIntervalsOverlapping,
   isEqual,
   parseISO,
+  formatISO,
   isSameDay
 } from "date-fns";
 import store from "@/store";
@@ -26,6 +27,26 @@ export function getShiftsOnSpecificDate(specificDate, contract) {
   return getContractShifts(contract.uuid).filter((shift) => {
     return isSameDay(parseISO(shift.date.start), specificDate);
   });
+}
+
+export function getWorktimeAndBreaktimeOnDate(shiftDate, contract) {
+  const formattedDate = {
+    start: formatISO(shiftDate.start),
+    end: formatISO(shiftDate.end)
+  };
+  // Copy Array
+  let shifts = getShiftsOnSpecificDate(formattedDate.start, contract).concat(
+    []
+  );
+  const indexOfShift = shifts.findIndex((shift) => shift.uuid === this.uuid);
+  if (indexOfShift === -1) {
+    return coalescWorktimeAndBreaktime(
+      shifts.concat([{ date: formattedDate }]) // this is a Hack, only passing an object with a date key.
+    );
+  }
+  // Update the shift's date to current date
+  shifts[indexOfShift].date = formattedDate;
+  return coalescWorktimeAndBreaktime(shifts);
 }
 
 export function datesGroupByComponent(dates, token) {

--- a/src/utils/shift.js
+++ b/src/utils/shift.js
@@ -1,5 +1,11 @@
 import { Shift } from "@/models/ShiftModel";
-import { areIntervalsOverlapping, isEqual, parseISO } from "date-fns";
+import {
+  areIntervalsOverlapping,
+  isEqual,
+  parseISO,
+  isSameDay
+} from "date-fns";
+import store from "@/store";
 import { localizedFormat } from "@/utils/date";
 import { coalescWorktimeAndBreaktime } from "@/utils/time";
 
@@ -8,6 +14,18 @@ function prepare({ start, end }) {
     start: parseISO(start),
     end: parseISO(end)
   };
+}
+
+export function getContractShifts(contractUuid) {
+  return store.getters["shift/shifts"].filter((shift) => {
+    return shift.contract === contractUuid;
+  });
+}
+
+export function getShiftsOnSpecificDate(specificDate, contract) {
+  return getContractShifts(contract.uuid).filter((shift) => {
+    return isSameDay(parseISO(shift.date.start), specificDate);
+  });
 }
 
 export function datesGroupByComponent(dates, token) {


### PR DESCRIPTION
toDos:
- [x] neue zentrale und multifunktionale Funktionen `getShiftsOnSpecificDay` in utils/shifts.js bauen/umziehen
- [x] neue zentrale und multifunktionale Funktionen `getContractShifts` in utils/shifts.js bauen/umziehen
- [x] neue zentrale und multifunktionale Funktionen `getWorktimeAndBreaktimeOnSpecificDate` in utils/shifts.js bauen/umziehen
- [x] neue zentrale und multifunktionale Funktionen `sickOrVacationShiftsOnSpecificDate` in utils/shifts.js bauen/umziehen
- [ ] neue zentrale und multifunktionale Funktionen `multipleRegularShiftsExistOnSpecificDate` in utils/shifts.js bauen/umziehen
- [ ] `shiftIsOverlapping` Validator zentral und multifunktional in utils/shift.js umziehen
- [ ] `maxShifttimeExceeded` nimmt als Argument nur noch eine `shift`
- [ ] renaming aller Validators mit `Validator` im Funktionsnamen
- [ ] prüfen ob zentrale Funktion `shiftIsValid` in utils/shift.js nützlich/sinnvoll
- [ ] ...