### PR TITLE
BUG: Error panel pops up upon shift is saved

### DIFF
--- a/src/components/cards/FormActions.vue
+++ b/src/components/cards/FormActions.vue
@@ -87,11 +87,9 @@ export default {
       } else {
         await this.updateFn();
       }
-      this.closeFn();
     },
     async destroy() {
       await this.deleteFn();
-      this.closeFn();
     },
     close() {
       this.$emit("close");

--- a/src/components/forms/dialogs/ShiftFormDialog.vue
+++ b/src/components/forms/dialogs/ShiftFormDialog.vue
@@ -15,6 +15,7 @@
           :color="btnColor"
           :text="textButton"
           v-on="on"
+          @click="opened = true"
         >
           {{ buttonText }}
         </v-btn>
@@ -32,9 +33,11 @@
         <ShiftForm
           :existing-shift="shift"
           :close="close"
+          :show-errors="opened"
           @save="$emit('save')"
           @delete="$emit('delete')"
           @update="$emit('update')"
+          @close="opened = false"
         ></ShiftForm>
       </template>
     </TheDialog>
@@ -86,7 +89,8 @@ export default {
         mdiPencil,
         mdiPlus
       },
-      show: this.value
+      show: this.value,
+      opened: true
     };
   },
   computed: {

--- a/src/components/forms/modelForms/shift/ShiftForm.vue
+++ b/src/components/forms/modelForms/shift/ShiftForm.vue
@@ -90,12 +90,10 @@ export default {
       this.initializeNewShift();
     },
     showErrors(opened) {
-      console.log("watcher fired");
       this.closed = !opened;
     }
   },
   created() {
-    console.log("created run");
     this.initializeNewShift();
   },
   methods: {

--- a/src/components/shifts/ShiftFormTimeInput.vue
+++ b/src/components/shifts/ShiftFormTimeInput.vue
@@ -29,7 +29,7 @@
         v-bind="attrs"
         @blur="setTime"
         @focus="$event.target.select()"
-        v-on="$vuetify.breakpoint.smAndDown ? { ...menuOn } : ''"
+        v-on="$vuetify.breakpoint.smAndDown ? menuOn : ''"
       ></v-text-field>
       <!--        </template>-->
       <!--        <span>{{ errorMessages[0] }} </span>-->

--- a/src/models/ShiftModel.js
+++ b/src/models/ShiftModel.js
@@ -12,13 +12,13 @@ import { localizedFormat } from "@/utils/date";
 import { minutesToHHMM } from "@/utils/time";
 import { any } from "ramda";
 
-// function defaultValueTime(type) {
-//   const today = new Date();
-//   const [hour, minute, second] = type === "start" ? [10, 0, 0] : [10, 30, 0];
-//   today.setHours(hour, minute, second);
-//
-//   return today;
-// }
+function defaultValueTime(type) {
+  const today = new Date();
+  const [hour, minute, second] = type === "start" ? [10, 0, 0] : [10, 30, 0];
+  today.setHours(hour, minute, second);
+
+  return today;
+}
 
 export function mapShiftApiResponse(response) {
   response["wasReviewed"] = response["was_reviewed"];
@@ -51,12 +51,12 @@ export class Shift {
     this.started =
       is(Date, new Date(started)) && started !== null
         ? new Date(started)
-        : null;
+        : defaultValueTime("start");
 
     this.stopped =
       is(Date, new Date(stopped)) && stopped !== null
         ? new Date(stopped)
-        : null;
+        : defaultValueTime("stop");
     this.contract = is(String, contract) ? contract : "";
     this.type =
       is(String, type) && any(SHIFT_TYPES.map((item) => item.value === type))

--- a/src/models/ShiftModel.js
+++ b/src/models/ShiftModel.js
@@ -12,13 +12,13 @@ import { localizedFormat } from "@/utils/date";
 import { minutesToHHMM } from "@/utils/time";
 import { any } from "ramda";
 
-function defaultValueTime(type) {
-  const today = new Date();
-  const [hour, minute, second] = type === "start" ? [10, 0, 0] : [10, 30, 0];
-  today.setHours(hour, minute, second);
-
-  return today;
-}
+// function defaultValueTime(type) {
+//   const today = new Date();
+//   const [hour, minute, second] = type === "start" ? [10, 0, 0] : [10, 30, 0];
+//   today.setHours(hour, minute, second);
+//
+//   return today;
+// }
 
 export function mapShiftApiResponse(response) {
   response["wasReviewed"] = response["was_reviewed"];
@@ -51,12 +51,12 @@ export class Shift {
     this.started =
       is(Date, new Date(started)) && started !== null
         ? new Date(started)
-        : defaultValueTime("start");
+        : null;
 
     this.stopped =
       is(Date, new Date(stopped)) && stopped !== null
         ? new Date(stopped)
-        : defaultValueTime("end");
+        : null;
     this.contract = is(String, contract) ? contract : "";
     this.type =
       is(String, type) && any(SHIFT_TYPES.map((item) => item.value === type))


### PR DESCRIPTION
Once a shift is saved, `initializeNewShift()` is called which may cause the `errorMessages`to update if the default "dummy shift" overlaps with it or is faulty in another way.
