### PR TITLE
Kein Feedback mehr möglich bevor DGSVO akzeptiert ist

### DIFF
--- a/src/components/OnboardDialog.vue
+++ b/src/components/OnboardDialog.vue
@@ -157,7 +157,6 @@
         @click:outside="personnelNumberDialog = false"
         ><PersonnelNumberForm dialog @close="personnelNumberDialog = false"
       /></v-dialog>
-      <FeedbackMenu />
     </v-card>
   </v-dialog>
 </template>
@@ -171,7 +170,6 @@ import {
   mdiRecord
 } from "@mdi/js";
 
-import FeedbackMenu from "@/components/FeedbackMenu";
 import GdprAgreementCard from "@/components/gdpr/GdprAgreementCard";
 import CardToolbar from "@/components/cards/CardToolbar";
 import ContractFormDialog from "@/components/forms/dialogs/ContractFormDialog";
@@ -183,7 +181,6 @@ export default {
   components: {
     PersonnelNumberForm,
     ContractFormDialog,
-    FeedbackMenu,
     GdprAgreementCard,
     CardToolbar
   },


### PR DESCRIPTION
Während des Onboardings war es noch möglich Feedback zu geben. Dies ist nicht vereinbar mit den Datenschutz, da eine Datenverarbeitung erst nach aktivem Akzeptieren der DSGVO-Richtlinien erlaubt ist.

closing #304 