### PR TITLE
Contract Validation Carryover

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -97,7 +97,8 @@
     },
     "createContract": "Vertrag erstellen",
     "errors": {
-      "shiftOutOfScope": "Bestehende Schichten müssen auch nach einer Änderung weiterhin im Vertragszeitraum liegen."
+      "shiftOutOfScope": "Bestehende Schichten müssen auch nach einer Änderung weiterhin im Vertragszeitraum liegen.",
+      "carryoverForFutureContracts": "Der Übertrag für einen zukünftigen Vertrag muss 00:00 sein."
     }
   },
   "dashboard": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -495,7 +495,7 @@
     },
     "errors": {
       "startedBeforeStopped": "The start must be before the end of the shift.",
-      "maximumworking timePerDay": "The maxium allowed working time amount is 10 hours per day.",
+      "maximumWorktimePerDay": "The maxium allowed working time amount is 10 hours per day.",
       "workingOnSundays": "It is not allowed to work on a sunday.",
       "workingOnHolidays": "You can only book 'holiday' shifts on a holiday.",
       "exclusiveVacation": "You can not combine 'vacation' shifts with other shifts on the same day.",
@@ -503,7 +503,7 @@
       "overlappingStarted": "The start time is within the period of an existing and reviewed shift.",
       "overlappingStopped": "The end time is within the period of an already existing and reviewed shift.",
       "eightTwentyRule": "As a rule, student workers should not be obliged to work before 08:00 and after 20:00.",
-      "autoworking timeCutting": "Mandatory breaktimes are missing on this workday. Clock will subtract the legally required breaktimes automatically from your working time.",
+      "autoWorktimeCutting": "Mandatory breaktimes are missing on this workday. Clock will subtract the legally required breaktimes automatically from your working time.",
       "month_already_locked": "This month has already been locked. You cannot save new shifts within this month."
     },
     "hints": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -404,8 +404,8 @@
     },
     "warnings": {
       "maxOvertimeExceeded": "You gathered more than 50% of your debit working time in overtime. Only 50% of you debit working time will be carried over to the next month as surplus hours.",
-      "insufficientworking time": "You are missing more than 20% of your debit working time.",
-      "working timeOverEightyHours": "Your total working time for this month is greater than 80h. Please keep in mind that you lose your students insurance status if you work more than 80h during the semester."
+      "insufficientWorktime": "You are missing more than 20% of your debit working time.",
+      "worktimeOverEightyHours": "Your total working time for this month is greater than 80h. Please keep in mind that you lose your students insurance status if you work more than 80h during the semester."
     }
   },
   "selectContract": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -97,7 +97,8 @@
     },
     "createContract": "Create Contract",
     "errors": {
-      "shiftOutOfScope": "Given shifts need to stay in scope after changing the contract duration."
+      "shiftOutOfScope": "Given shifts need to stay in scope after changing the contract duration.",
+      "carryoverForFutureContracts": "The carry over for a contract starting in the future may only be 00:00."
     }
   },
   "dashboard": {

--- a/src/mixins/ContractValidationMixin.js
+++ b/src/mixins/ContractValidationMixin.js
@@ -5,6 +5,7 @@ export default {
     errorMessages() {
       let errorMessages = [];
       errorMessages.push(this.validateDurationAndExistingShifts);
+      errorMessages.push(this.validateNoCarryoverForFutureContracts);
       return errorMessages.filter((message) => message !== undefined);
     },
     valid() {
@@ -21,6 +22,15 @@ export default {
         ) {
           return this.$t("contracts.errors.shiftOutOfScope");
         }
+      }
+    },
+    validateNoCarryoverForFutureContracts() {
+      const today = new Date();
+      if (
+        this.newContract.startDate > today &&
+        this.newContract.initialCarryoverMinutes !== 0
+      ) {
+        return this.$t("contracts.errors.carryoverForFutureContracts");
       }
     },
     shiftsThisContract() {


### PR DESCRIPTION
close #493 

Nachpflege [dieser Validation](https://github.com/ClockGU/clock-backend/blob/e9ba8ee467884b94d918c91e6aff3f7e796b5646/api/serializers.py#L185) aus dem Backend fürs Frontend