### PR TITLE
Contract Carryover und StatDatum nach Lock nicht mehr veränderbar

### DIFF
--- a/src/components/contracts/ContractDurationInput.vue
+++ b/src/components/contracts/ContractDurationInput.vue
@@ -4,7 +4,7 @@
       <ContractFormDateInput
         v-model="start"
         type="start"
-        :disabled="disabled"
+        :disabled="disabled || disableStart"
       />
     </v-col>
 
@@ -39,6 +39,11 @@ export default {
     endDate: {
       type: Date,
       required: true
+    },
+    disableStart: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data() {

--- a/src/components/forms/modelForms/contract/ContractFormFields.vue
+++ b/src/components/forms/modelForms/contract/ContractFormFields.vue
@@ -3,6 +3,7 @@
     <ContractDurationInput
       :start-date="contract.startDate"
       :end-date="contract.endDate"
+      :disable-start="areLockedShiftsInThisContract"
       @input="setDates"
     ></ContractDurationInput>
     <v-row align="center" justify="start">
@@ -32,11 +33,12 @@
         <v-checkbox
           v-model="showCarryover"
           :label="$t('contracts.carryover.checkboxLabel')"
+          :disabled="areLockedShiftsInThisContract"
           :error-messages="false ? $t('contracts.carryover.locked') : ''"
         ></v-checkbox>
         <v-expand-transition hide-on-leave mode="in">
           <div v-show="showCarryover">
-            <p>
+            <p v-show="!areLockedShiftsInThisContract">
               {{ $t("contracts.carryover.info") }}
             </p>
             <ContractFormTimeInput
@@ -45,6 +47,7 @@
               :label="$t('contracts.carryover.timeLabel')"
               :hint="$t('contracts.carryover.timeSubtitle')"
               allow-negative-values
+              :disabled="areLockedShiftsInThisContract"
               :required="showCarryover"
             />
           </div>


### PR DESCRIPTION
close #549 

Ich habe neben dem Carryover und der Eingabe für das StartDatum auch noch den Text über dem Carryover Input `disabled`.


Das sieht dann in Anwendung wie folgt aus:
![image](https://github.com/ClockGU/clock-frontend/assets/50986166/95891196-5394-45a4-b895-e7a907115af2)
