### PR TITLE
286.shifts table mobile view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ yarn-error.log*
 # Cypress
 tests/e2e/videos
 tests/e2e/screenshots
+_wildcard.clock.uni-frankfurt.de-key.pem
+_wildcard.clock.uni-frankfurt.de.pem
+.env.local
+CaddyFile

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,9 +20,13 @@
           >Clear User</v-btn
         >
       </v-alert>
-      <v-alert v-if="staging" type="warning" density="compact">{{
-        infostring
-      }}</v-alert>
+      <v-alert
+        v-if="staging"
+        type="warning"
+        density="compact"
+        class="pa-2 mx-4"
+        >{{ infostring }}</v-alert
+      >
       <v-container :style="styles" style="height: 100%">
         <router-view></router-view>
       </v-container>

--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -195,4 +195,9 @@ h1 {
   width: 100%;
   height: 100%;
 }
+@media (max-width: 960px) {
+  .mode-toggle {
+    margin-right: 20px;
+  }
+}
 </style>

--- a/src/components/forms/dialogs/ShiftFormDialog.vue
+++ b/src/components/forms/dialogs/ShiftFormDialog.vue
@@ -56,6 +56,8 @@ import ShiftForm from "@/components/forms/modelForms/shift/ShiftForm.vue";
 import { Shift } from "@/models/ShiftModel";
 import { mdiExclamation, mdiPencil, mdiPlus } from "@mdi/js";
 import ShiftValidationMixin from "@/mixins/ShiftValidationMixin";
+import breakpointsMixin from "@/mixins/breakpointsMixin";
+
 // eslint-disable-next-line no-unused-vars
 import store from "@/store";
 import { isBefore } from "date-fns";
@@ -63,7 +65,7 @@ import { isBefore } from "date-fns";
 export default {
   name: "ShiftFormDialog",
   components: { ShiftForm, TheDialog },
-  mixins: [ShiftValidationMixin],
+  mixins: [ShiftValidationMixin, breakpointsMixin],
   props: {
     shift: {
       type: Shift,
@@ -104,7 +106,7 @@ export default {
       default: false
     }
   },
-  emits: ["close", "save", "update", "delete", "update:modelValue"],
+  emits: ["close", "save", "update", "delete", "update:modelValue", "reset"],
   data() {
     return {
       icons: {
@@ -118,9 +120,6 @@ export default {
     };
   },
   computed: {
-    smAndDown() {
-      return this.$vuetify.display.smAndDown;
-    },
     create() {
       return this.shift === undefined;
     },
@@ -187,6 +186,7 @@ export default {
     closeFormDialog() {
       this.$emit("close");
       this.$emit("update:modelValue", false);
+      this.$emit("reset");
     }
   }
 };

--- a/src/components/forms/dialogs/ShiftFormDialog.vue
+++ b/src/components/forms/dialogs/ShiftFormDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <TheDialog
     v-model="show"
-    :fullscreen="isXs"
+    :fullscreen="xs"
     :max-width="600"
     :persistent="false"
     @close="closeFormDialog"

--- a/src/components/forms/dialogs/ShiftFormDialog.vue
+++ b/src/components/forms/dialogs/ShiftFormDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <TheDialog
     v-model="show"
-    :fullscreen="smAndDown"
+    :fullscreen="isXs"
     :max-width="600"
     :persistent="false"
     @close="closeFormDialog"

--- a/src/components/live_clock/LiveClock.vue
+++ b/src/components/live_clock/LiveClock.vue
@@ -182,7 +182,6 @@ async function clockOut() {
 //New way of created hook
 
 if (clockedInShift.value !== undefined) {
-  console.log("clockedInShift recoginized");
   initializeClock(clockedInShift.value.started);
   clock.value.start();
   setStatusRunning();

--- a/src/components/shifts/ShiftBulkActions.vue
+++ b/src/components/shifts/ShiftBulkActions.vue
@@ -28,7 +28,7 @@
           </template>
         </ShiftAssignContractDialog>
         <ShiftMoreInformationDialog
-          v-if="isXs"
+          v-if="xs"
           :disabled="shiftsLength !== 1"
           :shift="this.shifts[0]"
           @reset="resetFn()"
@@ -43,7 +43,7 @@
           </template>
         </ShiftMoreInformationDialog>
         <ShiftFormDialog
-          v-if="isXs"
+          v-if="xs"
           :create="false"
           :shift="this.shifts[0]"
           disable-activator="true"

--- a/src/components/shifts/ShiftBulkActions.vue
+++ b/src/components/shifts/ShiftBulkActions.vue
@@ -57,6 +57,11 @@
               v-bind="props"
               :icon="icons.mdiPencil"
             />
+            <ShiftWarningIcon
+              v-if="shiftsLength === 1"
+              style="transform: translate(-80%, -35%)"
+              :shift="this.shifts[0]"
+            ></ShiftWarningIcon>
           </template>
         </ShiftFormDialog>
         <ShiftBulkActionsDialogDelete
@@ -94,6 +99,7 @@ import {
   mdiInformationVariant
 } from "@mdi/js";
 import ShiftsDetailsDialog from "./ShiftsDetailsDialog.vue";
+import ShiftWarningIcon from "./ShiftWarningIcon.vue";
 
 export default {
   name: "ShiftBulkActions",
@@ -102,7 +108,8 @@ export default {
     ShiftBulkActionsDialogDelete,
     ShiftBulkActionsDialogReview,
     ShiftFormDialog,
-    ShiftsDetailsDialog
+    ShiftsDetailsDialog,
+    ShiftWarningIcon
   },
   props: {
     canReview: {

--- a/src/components/shifts/ShiftBulkActions.vue
+++ b/src/components/shifts/ShiftBulkActions.vue
@@ -27,7 +27,7 @@
             />
           </template>
         </ShiftAssignContractDialog>
-        <ShiftMoreInformationDialog
+        <ShiftsDetailsDialog
           v-if="xs"
           :disabled="shiftsLength !== 1"
           :shift="this.shifts[0]"
@@ -41,7 +41,7 @@
               v-bind="props"
             />
           </template>
-        </ShiftMoreInformationDialog>
+        </ShiftsDetailsDialog>
         <ShiftFormDialog
           v-if="xs"
           :create="false"
@@ -59,7 +59,6 @@
             />
           </template>
         </ShiftFormDialog>
-
         <ShiftBulkActionsDialogDelete
           :count="shiftsLength"
           @destroy="destroyFn"
@@ -94,7 +93,7 @@ import {
   mdiDelete,
   mdiInformationVariant
 } from "@mdi/js";
-import ShiftMoreInformationDialog from "./ShiftMoreInformationDialog.vue";
+import ShiftsDetailsDialog from "./ShiftsDetailsDialog.vue";
 
 export default {
   name: "ShiftBulkActions",
@@ -103,7 +102,7 @@ export default {
     ShiftBulkActionsDialogDelete,
     ShiftBulkActionsDialogReview,
     ShiftFormDialog,
-    ShiftMoreInformationDialog
+    ShiftsDetailsDialog
   },
   props: {
     canReview: {

--- a/src/components/shifts/ShiftBulkActions.vue
+++ b/src/components/shifts/ShiftBulkActions.vue
@@ -27,6 +27,38 @@
             />
           </template>
         </ShiftAssignContractDialog>
+        <ShiftMoreInformationDialog
+          v-if="smAndDown"
+          :disabled="shiftsLength !== 1"
+          :shift="this.shifts[0]"
+          @reset="resetFn()"
+        >
+          <template #activator="{ props }">
+            <v-btn
+              :disabled="shiftsLength !== 1"
+              variant="flat"
+              :icon="icons.mdiInformationVariant"
+              v-bind="props"
+            />
+          </template>
+        </ShiftMoreInformationDialog>
+        <ShiftFormDialog
+          v-if="smAndDown"
+          :create="false"
+          :shift="this.shifts[0]"
+          disable-activator="true"
+          @reset="resetFn()"
+          @update="updateFn(this.shifts[0].contract)"
+        >
+          <template #activator="{ props }">
+            <v-btn
+              :disabled="shiftsLength !== 1"
+              variant="flat"
+              v-bind="props"
+              :icon="icons.mdiPencil"
+            />
+          </template>
+        </ShiftFormDialog>
 
         <ShiftBulkActionsDialogDelete
           :count="shiftsLength"
@@ -51,21 +83,27 @@
 import ShiftAssignContractDialog from "@/components/shifts/ShiftAssignContractDialog.vue";
 import ShiftBulkActionsDialogDelete from "@/components/shifts/ShiftBulkActionsDialogDelete.vue";
 import ShiftBulkActionsDialogReview from "@/components/shifts/ShiftBulkActionsDialogReview.vue";
+import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
 import { minutesToHHMM } from "@/utils/time";
+import breakpointsMixin from "@/mixins/breakpointsMixin";
 import {
   mdiCheck,
   mdiCheckAll,
   mdiPencil,
   mdiSwapHorizontal,
-  mdiDelete
+  mdiDelete,
+  mdiInformationVariant
 } from "@mdi/js";
+import ShiftMoreInformationDialog from "./ShiftMoreInformationDialog.vue";
 
 export default {
   name: "ShiftBulkActions",
   components: {
     ShiftAssignContractDialog,
     ShiftBulkActionsDialogDelete,
-    ShiftBulkActionsDialogReview
+    ShiftBulkActionsDialogReview,
+    ShiftFormDialog,
+    ShiftMoreInformationDialog
   },
   props: {
     canReview: {
@@ -89,8 +127,16 @@ export default {
   },
   emits: ["destroy", "update"],
   data: () => ({
-    icons: { mdiCheck, mdiCheckAll, mdiPencil, mdiSwapHorizontal, mdiDelete }
+    icons: {
+      mdiCheck,
+      mdiCheckAll,
+      mdiPencil,
+      mdiSwapHorizontal,
+      mdiDelete,
+      mdiInformationVariant
+    }
   }),
+  mixins: [breakpointsMixin],
   computed: {
     reviewable() {
       return this.shifts.filter((shift) => shift.wasReviewed === false).length;
@@ -106,6 +152,7 @@ export default {
       return this.shifts.length;
     }
   },
+
   methods: {
     async destroyFn() {
       await this.$store.dispatch("contentData/bulkDeleteShifts", this.shifts);

--- a/src/components/shifts/ShiftBulkActions.vue
+++ b/src/components/shifts/ShiftBulkActions.vue
@@ -28,7 +28,7 @@
           </template>
         </ShiftAssignContractDialog>
         <ShiftMoreInformationDialog
-          v-if="smAndDown"
+          v-if="isXs"
           :disabled="shiftsLength !== 1"
           :shift="this.shifts[0]"
           @reset="resetFn()"
@@ -43,7 +43,7 @@
           </template>
         </ShiftMoreInformationDialog>
         <ShiftFormDialog
-          v-if="smAndDown"
+          v-if="isXs"
           :create="false"
           :shift="this.shifts[0]"
           disable-activator="true"

--- a/src/components/shifts/ShiftMoreInformationDialog.vue
+++ b/src/components/shifts/ShiftMoreInformationDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <TheDialog
     v-model="show"
-    :fullscreen="isXs"
+    :fullscreen="xs"
     :max-width="600"
     :persistent="false"
   >

--- a/src/components/shifts/ShiftMoreInformationDialog.vue
+++ b/src/components/shifts/ShiftMoreInformationDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <TheDialog
     v-model="show"
-    :fullscreen="smAndDown"
+    :fullscreen="isXs"
     :max-width="600"
     :persistent="false"
   >

--- a/src/components/shifts/ShiftMoreInformationDialog.vue
+++ b/src/components/shifts/ShiftMoreInformationDialog.vue
@@ -1,0 +1,212 @@
+<template>
+  <TheDialog
+    v-model="show"
+    :fullscreen="smAndDown"
+    :max-width="600"
+    :persistent="false"
+  >
+    <template #activator="props">
+      <slot name="activator" v-bind="props"></slot>
+    </template>
+    <template #content>
+      <v-card flat height="100%">
+        <CardToolbar
+          :title="title"
+          :logout-action="false"
+          close-action
+          @close="closeFn"
+        ></CardToolbar>
+        <br />
+
+        <v-table comfortable rounded class="mt-8 mx-4">
+          <tbody>
+            <tr>
+              <td class="font-weight-bold">{{ headers[0].title }}</td>
+              <td>{{ formattedDate(item.started) }}</td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">{{ headers[1].title }}</td>
+              <td>{{ formattedTime(item.started) }}</td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">{{ headers[2].title }}</td>
+              <td>{{ formattedDuration(item.duration) }}</td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">{{ headers[3].title }}</td>
+              <td>
+                <v-icon :color="colors[item.type]">
+                  {{ typeIcons[item.type] }}
+                </v-icon>
+                <v-chip
+                  v-if="isRunningShift(item)"
+                  class="ml-2"
+                  variant="outlined"
+                  x-small
+                  dense
+                  color="red"
+                >
+                  live
+                </v-chip>
+              </td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">{{ headers[4].title }}</td>
+              <td>
+                <v-btn
+                  v-if="!item.wasReviewed"
+                  :icon="icons.mdiClose"
+                  :disabled="isRunningShift(item)"
+                  color="red"
+                  variant="text"
+                  elevation="0"
+                  @click="reviewSingleShift(item)"
+                ></v-btn>
+                <v-btn
+                  v-else
+                  variant="text"
+                  :icon="icons.mdiCheck"
+                  color="green"
+                  elevation="0"
+                ></v-btn>
+              </td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">Tags</td>
+              <td>
+                <v-chip
+                  v-for="tag in item.tags.slice(0, 2)"
+                  :key="tag"
+                  class="mx-1"
+                  small
+                >
+                  {{ tag }}
+                </v-chip>
+                <ShiftInfoDialog v-if="item.tags.length > 2" :item="item">
+                  <template #activator="{ props }">
+                    <v-chip small class="mx-1" v-bind="props">...</v-chip>
+                  </template>
+                </ShiftInfoDialog>
+              </td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">Notes</td>
+              <td>
+                <ShiftInfoDialog :item="item">
+                  <template #activator="{ activatorProps }">
+                    <span v-bind="activatorProps">{{
+                      noteDisplay(item.note, 550)
+                    }}</span>
+                  </template>
+                </ShiftInfoDialog>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+        <v-spacer></v-spacer>
+        <div class="d-flex justify-center ga-4 my-8">
+          <ShiftFormDialog
+            :shift="item"
+            disable-activator="true"
+            @update="updateShift"
+          >
+            <template #activator="{ props }">
+              <v-btn
+                color="primary"
+                class="py-2"
+                size="large"
+                variant="text"
+                :prepend-icon="icons.mdiPencil"
+                v-bind="props"
+                >{{ $t("actions.edit") }}</v-btn
+              >
+            </template>
+          </ShiftFormDialog>
+          <ShiftBulkActionsDialogDelete @destroy="destroySingleShift(item)">
+            <template #activator="{ props }">
+              <v-btn
+                color="red"
+                class="py-2"
+                size="large"
+                variant="text"
+                :prepend-icon="icons.mdiDelete"
+                v-bind="props"
+                >{{ $t("actions.delete") }}</v-btn
+              >
+            </template>
+          </ShiftBulkActionsDialogDelete>
+        </div>
+      </v-card>
+    </template>
+  </TheDialog>
+</template>
+
+<script>
+import ShiftBulkActionsDialogDelete from "@/components/shifts/ShiftBulkActionsDialogDelete.vue";
+import TheDialog from "@/components/TheDialog.vue";
+import ShiftInfoDialog from "@/components/shifts/ShiftInfoDialog.vue";
+import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
+import CardToolbar from "@/components/cards/CardToolbar.vue";
+import ShiftUtilityMixin from "@/mixins/ShiftUtilityMixin";
+import breakpointsMixin from "@/mixins/breakpointsMixin";
+
+export default {
+  name: "ShiftMoreInformationDialog",
+  components: {
+    TheDialog,
+    ShiftFormDialog,
+    ShiftInfoDialog,
+    ShiftBulkActionsDialogDelete,
+    CardToolbar
+  },
+  props: {
+    shift: {
+      type: Object,
+      required: false,
+      default: undefined
+    },
+    modelValue: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ["close", "update:modelValue", "reset"],
+  mixins: [ShiftUtilityMixin, breakpointsMixin],
+  data() {
+    return {
+      item: this.shift,
+      show: this.modelValue,
+      title: "View Shift Details"
+    };
+  },
+  watch: {
+    shift(newShift) {
+      this.item = newShift;
+    },
+    modelValue(newValue) {
+      this.show = newValue;
+    }
+  },
+  methods: {
+    async destroySingleShift(shift) {
+      try {
+        this.$store.commit("contentData/removeShift", {
+          contractID: shift.contract,
+          shiftInstance: shift
+        });
+        this.$emit("reset");
+      } catch (error) {
+        console.error(`Error deleting shift ${shift.id}`, error);
+      }
+    },
+    closeFn() {
+      this.show = false;
+    },
+    updateShift(updatedShift) {
+      this.item = updatedShift;
+      this.$emit("reset");
+    }
+  }
+};
+</script>
+``

--- a/src/components/shifts/ShiftMoreInformationDialog.vue
+++ b/src/components/shifts/ShiftMoreInformationDialog.vue
@@ -21,19 +21,19 @@
         <v-table comfortable rounded class="mt-8 mx-4">
           <tbody>
             <tr>
-              <td class="font-weight-bold">{{ headers[0].title }}</td>
+              <td class="font-weight-bold w-33">{{ headers[0].title }}</td>
               <td>{{ formattedDate(item.started) }}</td>
             </tr>
             <tr>
-              <td class="font-weight-bold">{{ headers[1].title }}</td>
+              <td class="font-weight-bold w-33">{{ headers[1].title }}</td>
               <td>{{ formattedTime(item.started) }}</td>
             </tr>
             <tr>
-              <td class="font-weight-bold">{{ headers[2].title }}</td>
+              <td class="font-weight-bold w-33">{{ headers[2].title }}</td>
               <td>{{ formattedDuration(item.duration) }}</td>
             </tr>
             <tr>
-              <td class="font-weight-bold">{{ headers[3].title }}</td>
+              <td class="font-weight-bold w-33">{{ headers[3].title }}</td>
               <td>
                 <v-icon :color="colors[item.type]">
                   {{ typeIcons[item.type] }}
@@ -51,12 +51,13 @@
               </td>
             </tr>
             <tr>
-              <td class="font-weight-bold">{{ headers[4].title }}</td>
+              <td class="font-weight-bold w-33">{{ headers[4].title }}</td>
               <td>
                 <v-btn
                   v-if="!item.wasReviewed"
                   :icon="icons.mdiClose"
                   :disabled="isRunningShift(item)"
+                  class="w-0 ml-2"
                   color="red"
                   variant="text"
                   elevation="0"
@@ -66,13 +67,14 @@
                   v-else
                   variant="text"
                   :icon="icons.mdiCheck"
+                  class="w-0 ml-2"
                   color="green"
                   elevation="0"
                 ></v-btn>
               </td>
             </tr>
             <tr>
-              <td class="font-weight-bold">Tags</td>
+              <td class="font-weight-bold w-33">Tags</td>
               <td>
                 <v-chip
                   v-for="tag in item.tags.slice(0, 2)"
@@ -90,7 +92,7 @@
               </td>
             </tr>
             <tr>
-              <td class="font-weight-bold">Notes</td>
+              <td class="font-weight-bold w-33">Notes</td>
               <td>
                 <ShiftInfoDialog :item="item">
                   <template #activator="{ activatorProps }">

--- a/src/components/shifts/ShiftMoreInformationDialog.vue
+++ b/src/components/shifts/ShiftMoreInformationDialog.vue
@@ -175,8 +175,7 @@ export default {
   data() {
     return {
       item: this.shift,
-      show: this.modelValue,
-      title: "View Shift Details"
+      show: this.modelValue
     };
   },
   watch: {
@@ -185,6 +184,11 @@ export default {
     },
     modelValue(newValue) {
       this.show = newValue;
+    }
+  },
+  computed: {
+    title() {
+      return this.$t("shifts.viewDetails");
     }
   },
   methods: {

--- a/src/components/shifts/ShiftWarningIcon.vue
+++ b/src/components/shifts/ShiftWarningIcon.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-icon v-if="alertMessages.length > 0" color="warning">
+    {{ icons.mdiExclamation }}
+  </v-icon>
+</template>
+
+<script>
+import ShiftValidationMixin from "@/mixins/ShiftValidationMixin";
+import { mdiExclamation } from "@mdi/js";
+import { Shift } from "@/models/ShiftModel";
+
+export default {
+  name: "ShiftWarning",
+  mixins: [ShiftValidationMixin],
+  props: {
+    shift: {
+      type: Shift,
+      required: true,
+      default: undefined
+    }
+  },
+  data() {
+    return {
+      icons: {
+        mdiExclamation
+      }
+    };
+  }
+};
+</script>

--- a/src/components/shifts/ShiftsDetailsDialog.vue
+++ b/src/components/shifts/ShiftsDetailsDialog.vue
@@ -153,7 +153,7 @@ import ShiftUtilityMixin from "@/mixins/ShiftUtilityMixin";
 import breakpointsMixin from "@/mixins/breakpointsMixin";
 
 export default {
-  name: "ShiftMoreInformationDialog",
+  name: "ShiftsDetailsDialog",
   components: {
     TheDialog,
     ShiftFormDialog,

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -3,6 +3,7 @@
     <slot name="head" :selected="selected" :reset="reset"></slot>
     <v-data-table
       v-model="selected"
+      :show-select="!isMobile"
       :headers="flexHeaders"
       :items="shifts"
       :search="search"
@@ -13,14 +14,13 @@
       :custom-sort="sortByDate"
       must-sort
       :sort-desc="!pastShifts"
-      :show-select="!smAndDown"
     >
       <template #item="{ item }">
         <tr
           :class="{ 'selected-row': selected.includes(item) }"
           @click="handleClick(item)"
         >
-          <td class="d-none d-sm-table-cell">
+          <td v-if="!isMobile">
             <v-checkbox-btn
               class="table-checkbox-btn"
               v-model="selected"
@@ -143,6 +143,9 @@ import { ShiftService } from "@/services/models";
 import ShiftUtilityMixin from "@/mixins/ShiftUtilityMixin";
 import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
 import breakpointsMixin from "@/mixins/breakpointsMixin";
+import { fa } from "vuetify/lib/locale/index.mjs";
+import { tr } from "date-fns/locale";
+import { is } from "ramda";
 
 export default {
   name: "ShiftsTable",
@@ -185,7 +188,7 @@ export default {
 
       let filteredHeaders = [...this.headers];
 
-      if (this.smAndDown) {
+      if (this.isXs && this.isMobile) {
         filteredHeaders = filteredHeaders.filter((item) => {
           const title = item.title;
           return (

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -13,100 +13,93 @@
       :custom-sort="sortByDate"
       must-sort
       :sort-desc="!pastShifts"
-      show-select
+      :show-select="!smAndDown"
     >
-      <!-- eslint-disable-next-line -->
-      <template #item.date="{ item }">
-        {{ formattedDate(item.started) }}
-      </template>
-
-      <!-- eslint-disable-next-line -->
-      <template #item.start="{ item }">
-        {{ formattedTime(item.started) }}
-      </template>
-
-      <!-- eslint-disable-next-line -->
-      <template #item.duration="{ item }">
-        {{ formattedDuration(item.duration) }}
-      </template>
-
-      <!-- eslint-disable-next-line -->
-      <template #item.type="{ item }">
-        <v-icon :color="colors[item.type]">
-          {{ typeIcons[item.type] }}
-        </v-icon>
-        <v-chip
-          v-if="isRunningShift(item)"
-          class="ml-2"
-          variant="outlined"
-          x-small
-          dense
-          color="red"
+      <template #item="{ item }">
+        <tr
+          :class="{ 'selected-row': selected.includes(item) }"
+          @click="handleClick(item)"
         >
-          live
-        </v-chip>
+          <td class="d-none d-sm-table-cell">
+            <v-checkbox-btn
+              class="table-checkbox-btn"
+              v-model="selected"
+              :value="item"
+            />
+          </td>
+          <td>{{ formattedDate(item.started) }}</td>
+          <td>{{ formattedTime(item.started) }}</td>
+          <td>{{ formattedDuration(item.duration) }}</td>
+          <td>
+            <v-icon :color="colors[item.type]">
+              {{ typeIcons[item.type] }}
+            </v-icon>
+            <v-chip
+              v-if="isRunningShift(item)"
+              class="ml-2"
+              variant="outlined"
+              x-small
+              dense
+              color="red"
+            >
+              live
+            </v-chip>
+          </td>
+          <td v-if="pastShifts" class="d-none d-sm-table-cell">
+            <v-btn
+              v-if="!item.wasReviewed"
+              :icon="icons.mdiClose"
+              :disabled="isRunningShift(item)"
+              color="red"
+              variant="text"
+              elevation="0"
+              @click="reviewSingleShift(item)"
+            ></v-btn>
+            <v-btn
+              v-else
+              variant="text"
+              :icon="icons.mdiCheck"
+              color="green"
+              elevation="0"
+            ></v-btn>
+          </td>
+          <td class="d-none d-sm-table-cell">
+            <v-chip
+              v-for="tag in item.tags.slice(0, 2)"
+              :key="tag"
+              class="mx-1"
+              small
+            >
+              {{ tag }}
+            </v-chip>
+            <ShiftInfoDialog v-if="item.tags.length > 2" :item="item">
+              <template #activator="{ props }">
+                <v-chip small class="mx-1" v-bind="props">...</v-chip>
+              </template>
+            </ShiftInfoDialog>
+          </td>
+          <td class="d-none d-sm-table-cell">
+            <ShiftInfoDialog :item="item">
+              <template #activator="{ props }">
+                <span v-bind="props">{{ noteDisplay(item.note, 15) }}</span>
+              </template>
+            </ShiftInfoDialog>
+          </td>
+          <td class="d-none d-sm-table-cell">
+            <ShiftFormDialog
+              :create="false"
+              icon
+              :shift="item"
+            ></ShiftFormDialog>
+          </td>
+        </tr>
       </template>
+    </v-data-table>
+  </div>
+</template>
 
-      <!-- eslint-disable-next-line -->
-      <template v-if="pastShifts" #item.reviewed="{ item }">
-        <v-btn
-          v-if="!item.wasReviewed"
-          :icon="icons.mdiClose"
-          :disabled="isRunningShift(item)"
-          color="red"
-          variant="text"
-          elevation="0"
-          @click="reviewSingleShift(item)"
-        >
-        </v-btn>
-        <v-btn
-          v-else
-          variant="text"
-          :icon="icons.mdiCheck"
-          color="green"
-          elevation="0"
-        >
-        </v-btn>
-      </template>
-
-      <!-- eslint-disable-next-line -->
-      <template v-else #item.reviewed="{ item }">
-        <v-icon color="red">{{ icons.mdiClose }}</v-icon>
-      </template>
-
-      <!-- eslint-disable-next-line -->
-      <template #item.tags="{ item }">
-        <v-chip
-          v-for="tag in item.tags.slice(0, 2)"
-          :key="tag"
-          class="mx-1"
-          small
-        >
-          {{ tag }}
-        </v-chip>
-        <ShiftInfoDialog v-if="item.tags.length > 2" :item="item">
-          <template #activator="{ props }">
-            <v-chip small class="mx-1" v-bind="props">...</v-chip>
-          </template>
-        </ShiftInfoDialog>
-      </template>
-
-      <!-- eslint-disable-next-line -->
-      <template #item.note="{ item }">
-        <ShiftInfoDialog :item="item">
-          <template #activator="{ props }">
-            <span v-bind="props">
-              {{ noteDisplay(item.note) }}
-            </span>
-          </template>
-        </ShiftInfoDialog>
-      </template>
-
-      <!-- eslint-disable-next-line-->
-      <template #item.actions="{ item }">
-        <ShiftFormDialog :create="false" icon :shift="item"></ShiftFormDialog>
-        <!-- Commented out, pending due to missing Userfeedback.       -->
-        <!--ShiftAssignContractDialog :shifts="[item]" @reset="$emit('refresh')">
+<!-- Commented out, pending due to missing Userfeedback.       -->
+<!--ShiftAssignContractDialog :shifts="[item]" @reset="$emit('refresh')">
           <template #activator="{ on }">
             <v-btn icon v-on="on">
               <v-icon>{{ icons.mdiSwapHorizontal }}</v-icon>
@@ -114,7 +107,7 @@
           </template>
         </ShiftAssignContractDialog-->
 
-        <!--ConfirmationDialog @confirm="destroySingleShift(item)">
+<!--ConfirmationDialog @confirm="destroySingleShift(item)">
           <template #activator="{ on }">
             <v-scale-transition>
               <v-btn elevation="1" icon v-on="on">
@@ -141,38 +134,15 @@
             }}
           </template>
         </ConfirmationDialog-->
-      </template>
-    </v-data-table>
-  </div>
-</template>
 
 <script>
 //import ConfirmationDialog from "@/components/ConfirmationDialog";
 //import ShiftAssignContractDialog from "@/components/shifts/ShiftAssignContractDialog";
 import ShiftInfoDialog from "@/components/shifts/ShiftInfoDialog.vue";
-
-import { isWithinInterval, isBefore, getHours } from "date-fns";
-
-import {
-  mdiCheck,
-  mdiClose,
-  mdiCircleMedium,
-  mdiTagOutline,
-  mdiFileDocumentOutline,
-  mdiPencil,
-  mdiSwapHorizontal,
-  mdiDelete
-} from "@mdi/js";
-
-import { SHIFT_TABLE_HEADERS } from "@/utils/misc";
-import { SHIFT_TYPE_ICONS } from "@/utils/misc";
-
 import { ShiftService } from "@/services/models";
-import { log } from "@/utils/log";
-import { SHIFT_TYPE_COLORS } from "@/utils/colors";
-import { localizedFormat } from "@/utils/date";
-import { minutesToHHMM } from "@/utils/time";
+import ShiftUtilityMixin from "@/mixins/ShiftUtilityMixin";
 import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
+import breakpointsMixin from "@/mixins/breakpointsMixin";
 
 export default {
   name: "ShiftsTable",
@@ -198,91 +168,55 @@ export default {
     pastShifts: { type: Boolean, default: false }
   },
   emits: ["refresh"],
+  mixins: [ShiftUtilityMixin, breakpointsMixin],
+  /**
+   * @typedef {Object} Data
+   * @property {Object} [data] - component data
+   * @return {Data}
+   */
   data: () => ({
-    icons: {
-      mdiCheck,
-      mdiClose,
-      mdiCircleMedium,
-      mdiTagOutline,
-      mdiFileDocumentOutline,
-      mdiPencil,
-      mdiSwapHorizontal,
-      mdiDelete
-    },
-    headers: SHIFT_TABLE_HEADERS,
-    colors: SHIFT_TYPE_COLORS,
-    typeIcons: SHIFT_TYPE_ICONS,
     selected: []
   }),
   computed: {
     flexHeaders() {
-      //check for tags and notes and hide column if none exist
-      let tagsAndNotes = 0;
-      this.shifts.forEach(
-        (shift) => (tagsAndNotes += shift.tags.length && shift.note.length)
+      const tagsAndNotesExist = this.shifts.some(
+        (shift) => shift.tags.length > 0 || shift.note.length > 0
       );
-      if (tagsAndNotes === 0) {
-        return this.headers.filter((item) => item.value !== "tagsNotes");
+
+      let filteredHeaders = [...this.headers];
+
+      if (this.smAndDown) {
+        filteredHeaders = filteredHeaders.filter((item) => {
+          const title = item.title;
+          return (
+            title !== this.$t("time.reviewed") &&
+            title !== "Tags" &&
+            title !== "Notes" &&
+            title !== undefined
+          );
+        });
       }
 
-      return this.headers;
+      if (!tagsAndNotesExist) {
+        filteredHeaders = filteredHeaders.filter(
+          (item) => item.value !== "tagsNotes"
+        );
+      }
+      return filteredHeaders;
     }
   },
+
   methods: {
-    isRunningShift(shift) {
-      return isWithinInterval(new Date(), {
-        start: shift.started,
-        end: shift.stopped
-      });
+    handleClick(shift) {
+      const index = this.selected.indexOf(shift);
+
+      if (index > -1) {
+        this.selected.splice(index, 1);
+      } else {
+        this.selected.push(shift);
+      }
     },
-    formattedDate(date) {
-      return localizedFormat(date, "EEEE',' do' 'MMMM");
-    },
-    formattedTime(time) {
-      return localizedFormat(time, "HH:mm");
-    },
-    formattedDuration(duration) {
-      return minutesToHHMM(duration, "");
-    },
-    sortByDate(items, sortBy, sortDesc) {
-      const desc = sortDesc[0] ? -1 : 1;
-      items.sort((a, b) => {
-        switch (sortBy[0]) {
-          case "date":
-            return isBefore(b.started, a.started) ? -desc : desc;
-          case "start":
-            return isBefore(getHours(b.started), getHours(a.started))
-              ? -desc
-              : desc;
-          default:
-            return a[sortBy[0]] > b[sortBy[0]] ? -desc : desc;
-        }
-      });
-      return items;
-    },
-    noteDisplay(note) {
-      if (note.length > 15) {
-        return note.substr(0, 15) + "...";
-      } else return note;
-    },
-    // async destroy() {
-    //   const promises = [];
-    //   try {
-    //     for (const shift of this.selected) {
-    //       promises.push(ShiftService.delete(shift.id));
-    //     }
-    //
-    //     await Promise.all(promises);
-    //
-    //     this.$emit("refresh");
-    //     this.reset();
-    //   } catch (error) {
-    //     // TODO: Set error state for component & allow user to reload page
-    //     // We usually should end up here, if we are already logging out.
-    //     // But a proper error state could mitigate further issues.
-    //     log(error);
-    //   }
-    // },
+
     async destroySingleShift(shift) {
       try {
         await ShiftService.delete(shift.uuid);
@@ -296,24 +230,17 @@ export default {
         log(error);
       }
     },
-    async reviewSingleShift(shift) {
-      try {
-        const payload = shift.toPayload();
-        payload.was_reviewed = true;
-        await this.$store.dispatch("contentData/updateShift", {
-          payload,
-          initialContract: payload.contract
-        });
-      } catch (error) {
-        // TODO: Set error state for component & allow user to reload page
-        // We usually should end up here, if we are already logging out.
-        // But a proper error state could mitigate further issues.
-        log(error);
-      }
-    },
     reset() {
       this.selected = [];
     }
   }
 };
 </script>
+<style>
+.selected-row {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+.table-checkbox-btn {
+  right: 8px;
+}
+</style>

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -3,7 +3,7 @@
     <slot name="head" :selected="selected" :reset="reset"></slot>
     <v-data-table
       v-model="selected"
-      :show-select="!isMobile"
+      :show-select="!mobile"
       :headers="flexHeaders"
       :items="shifts"
       :search="search"
@@ -20,7 +20,7 @@
           :class="{ 'selected-row': selected.includes(item) }"
           @click="handleClick(item)"
         >
-          <td v-if="!isMobile">
+          <td v-if="!mobile">
             <v-checkbox-btn
               class="table-checkbox-btn"
               v-model="selected"
@@ -29,7 +29,7 @@
           </td>
           <td>
             {{
-              isXs
+              xs
                 ? formattedDateMobile(item.started)
                 : formattedDate(item.started)
             }}
@@ -37,7 +37,7 @@
           <td>{{ formattedTime(item.started) }}</td>
           <td>{{ formattedDuration(item.duration) }}</td>
           <td>
-            <div v-if="isXs">
+            <div v-if="xs">
               <v-icon :color="colors[item.type]" style="position: relative">
                 {{ typeIcons[item.type] }}
               </v-icon>
@@ -233,7 +233,7 @@ export default {
 
       let filteredHeaders = [...this.headers];
 
-      if (this.isXs && this.isMobile) {
+      if (this.xs && this.mobile) {
         filteredHeaders = filteredHeaders.filter((item) => {
           const title = item.title;
           return (

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -27,7 +27,13 @@
               :value="item"
             />
           </td>
-          <td>{{ formattedDateMobile(item.started) }}</td>
+          <td>
+            {{
+              isXs
+                ? formattedDateMobile(item.started)
+                : formattedDate(item.started)
+            }}
+          </td>
           <td>{{ formattedTime(item.started) }}</td>
           <td>{{ formattedDuration(item.duration) }}</td>
           <td>

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -27,7 +27,7 @@
               :value="item"
             />
           </td>
-          <td>{{ formattedDate(item.started) }}</td>
+          <td>{{ formattedDateMobile(item.started) }}</td>
           <td>{{ formattedTime(item.started) }}</td>
           <td>{{ formattedDuration(item.duration) }}</td>
           <td>
@@ -143,9 +143,7 @@ import { ShiftService } from "@/services/models";
 import ShiftUtilityMixin from "@/mixins/ShiftUtilityMixin";
 import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
 import breakpointsMixin from "@/mixins/breakpointsMixin";
-import { fa } from "vuetify/lib/locale/index.mjs";
-import { tr } from "date-fns/locale";
-import { is } from "ramda";
+import { localizedFormat } from "@/utils/date";
 
 export default {
   name: "ShiftsTable",
@@ -172,11 +170,7 @@ export default {
   },
   emits: ["refresh"],
   mixins: [ShiftUtilityMixin, breakpointsMixin],
-  /**
-   * @typedef {Object} Data
-   * @property {Object} [data] - component data
-   * @return {Data}
-   */
+
   data: () => ({
     selected: []
   }),
@@ -210,6 +204,11 @@ export default {
   },
 
   methods: {
+    formattedDateMobile(date) {
+      return this.$i18n.locale === "en"
+        ? localizedFormat(date, "EEE',' do")
+        : localizedFormat(date, "EEE ' ' do");
+    },
     handleClick(shift) {
       const index = this.selected.indexOf(shift);
 

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -35,7 +35,7 @@
                 :icon="icons.mdiClose"
                 :disabled="isRunningShift(item)"
                 color="red"
-                variant="text"
+                variant="outline"
                 elevation="0"
                 @click="reviewSingleShift(item)"
               ></v-btn>

--- a/src/components/shifts/ShiftsTable.vue
+++ b/src/components/shifts/ShiftsTable.vue
@@ -28,73 +28,51 @@
             />
           </td>
           <td>
-            {{
-              xs
-                ? formattedDateMobile(item.started)
-                : formattedDate(item.started)
-            }}
+            <div v-if="xs" class="d-flex align-center">
+              <span>{{ formattedDateMobile(item.started) }}</span>
+              <v-btn
+                v-if="!item.wasReviewed"
+                :icon="icons.mdiClose"
+                :disabled="isRunningShift(item)"
+                color="red"
+                variant="text"
+                elevation="0"
+                @click="reviewSingleShift(item)"
+              ></v-btn>
+              <v-btn
+                v-else
+                variant="text"
+                :icon="icons.mdiCheck"
+                color="green"
+                elevation="0"
+              ></v-btn>
+            </div>
+            <span v-else> {{ formattedDate(item.started) }}</span>
           </td>
           <td>{{ formattedTime(item.started) }}</td>
-          <td>{{ formattedDuration(item.duration) }}</td>
           <td>
-            <div v-if="xs">
-              <v-icon :color="colors[item.type]" style="position: relative">
-                {{ typeIcons[item.type] }}
-              </v-icon>
-
-              <v-chip
-                v-if="isRunningShift(item)"
-                class="ml-2"
-                variant="outlined"
-                x-small
-                dense
-                color="red"
-              >
-                live
-              </v-chip>
-
-              <div
-                style="
-                  position: absolute;
-                  top: 10px;
-                  right: 0;
-                  left: 18px;
-                  bottom: 0;
-                "
-              >
-                <v-btn
-                  v-if="!item.wasReviewed"
-                  :icon="icons.mdiClose"
-                  :disabled="isRunningShift(item)"
-                  color="red"
-                  variant="text"
-                  elevation="0"
-                  @click="reviewSingleShift(item)"
-                ></v-btn>
-                <v-btn
-                  v-else
-                  variant="text"
-                  :icon="icons.mdiCheck"
-                  color="green"
-                  elevation="0"
-                ></v-btn>
-              </div>
-            </div>
-            <div v-else>
-              <v-icon :color="colors[item.type]">
-                {{ typeIcons[item.type] }}
-              </v-icon>
-              <v-chip
-                v-if="isRunningShift(item)"
-                class="ml-2"
-                variant="outlined"
-                x-small
-                dense
-                color="red"
-              >
-                live
-              </v-chip>
-            </div>
+            <span>{{ formattedDuration(item.duration) }}</span>
+            <ShiftWarningIcon
+              v-if="xs"
+              :shift="item"
+              style="transform: translate(-35%, -35%)"
+            >
+            </ShiftWarningIcon>
+          </td>
+          <td>
+            <v-icon :color="colors[item.type]">
+              {{ typeIcons[item.type] }}
+            </v-icon>
+            <v-chip
+              v-if="isRunningShift(item)"
+              class="ml-2"
+              variant="outlined"
+              x-small
+              dense
+              color="red"
+            >
+              live
+            </v-chip>
           </td>
           <td v-if="pastShifts" class="d-none d-sm-table-cell">
             <v-btn
@@ -195,6 +173,7 @@ import ShiftUtilityMixin from "@/mixins/ShiftUtilityMixin";
 import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
 import breakpointsMixin from "@/mixins/breakpointsMixin";
 import { localizedFormat } from "@/utils/date";
+import ShiftWarningIcon from "@/components/shifts/ShiftWarningIcon.vue";
 
 export default {
   name: "ShiftsTable",
@@ -202,7 +181,8 @@ export default {
     ShiftFormDialog,
     //ConfirmationDialog,
     //  ShiftAssignContractDialog,
-    ShiftInfoDialog
+    ShiftInfoDialog,
+    ShiftWarningIcon
   },
   props: {
     loading: {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -546,7 +546,8 @@
       "faqLinkText": "Hier geht es zu den FAQ.",
       "ombudsText": "Benötigst du Unterstützung bei Problemen mit deinen Arbeitsbedingungen?",
       "ombudsLinkText": "Kontaktiere die Ombudsperson für Studierende."
-    }
+    },
+    "viewDetails": "Schichtdetails anzeigen"
   },
   "snackbar": {
     "success": "Die Aktion wurde durchgeführt.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -523,7 +523,7 @@
     "wasExportedAlert": "Der Stundenzettel für diesen Vertrag wurde schon exportiert. Du kannst diese Schicht nicht mehr bearbeiten.",
     "table": {
       "pastShiftsTitle": "Vergangene Schichten ({0})",
-      "pastShiftsHint": "Alle Schichten die in der Vergangenheit liegen. Geclockte und manuell hinzugefügte Schichten gelten als 'überprüft'.",
+      "pastShiftsHint": "Alle Schichten die in der Vergangenheit liegen. Geclockte und manuell hinzugefügte Schichten gelten als 'überprüft'",
       "futureShiftsTitle": "Zukünftige Schichten ({0})",
       "futureShiftsHint": "Alle in der Zukunft liegenden Schichten.",
       "tagsNotes": "Tags/Notizen"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -523,7 +523,7 @@
     "wasExportedAlert": "The timesheet this shift belongs to has already been exported. This shift cannot be edited anymore.",
     "table": {
       "pastShiftsTitle": "Past shifts ({0})",
-      "pastShiftsHint": "Clocked shifts and manually entered shifts are considered as 'reviewed' if they are past.",
+      "pastShiftsHint": "Clocked shifts and manually entered shifts are considered as 'reviewed' if they are past",
       "futureShiftsTitle": "Future shifts ({0})",
       "futureShiftsHint": "All shifts scheduled for the future.",
       "tagsNotes": "Tags/Notes"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -546,7 +546,8 @@
       "faqLinkText": "Check out the FAQ.",
       "ombudsText": "Do you need support for problems with your working conditions?",
       "ombudsLinkText": "Contact the ombudsperson for student affairs."
-    }
+    },
+    "viewDetails": "view Shift details"
   },
   "snackbar": {
     "success": "The action was completed.",

--- a/src/mixins/ShiftUtilityMixin.js
+++ b/src/mixins/ShiftUtilityMixin.js
@@ -1,15 +1,165 @@
-import { isFuture, isWithinInterval } from "date-fns";
+import { isWithinInterval, isBefore, getHours, isFuture, max } from "date-fns";
+import {
+  mdiCheck,
+  mdiClose,
+  mdiCircleMedium,
+  mdiTagOutline,
+  mdiFileDocumentOutline,
+  mdiPencil,
+  mdiSwapHorizontal,
+  mdiDelete
+} from "@mdi/js";
+import { SHIFT_TYPE_ICONS } from "@/utils/misc";
+import { SHIFT_TYPE_COLORS } from "@/utils/colors";
+import { localizedFormat } from "@/utils/date";
+import { minutesToHHMM } from "@/utils/time";
+import { log } from "@/utils/log";
 
 export default {
+  data() {
+    return {
+      icons: {
+        mdiCheck,
+        mdiClose,
+        mdiCircleMedium,
+        mdiTagOutline,
+        mdiFileDocumentOutline,
+        mdiPencil,
+        mdiSwapHorizontal,
+        mdiDelete
+      },
+      typeIcons: SHIFT_TYPE_ICONS,
+      colors: SHIFT_TYPE_COLORS,
+      selected: []
+    };
+  },
   computed: {
-    isRunningShift() {
-      return isWithinInterval(new Date(), {
-        start: this.shift.started,
-        end: this.shift.stopped
-      });
+    headers() {
+      return [
+        {
+          title: this.$t("time.date"),
+          align: "start",
+          sortable: true,
+          key: "date"
+        },
+        {
+          title: this.$t("time.start"),
+          align: "start",
+          sortable: true,
+          key: "start"
+        },
+        {
+          title: this.$t("time.duration"),
+          align: "start",
+          sortable: true,
+          key: "duration"
+        },
+        {
+          title: this.$t("calendar.type"),
+          align: "start",
+          sortable: true,
+          key: "type"
+        },
+        {
+          title: this.$t("time.reviewed"),
+          align: "start",
+          sortable: true,
+          key: "reviewed"
+        },
+        {
+          title: "Tags",
+          align: "start",
+          sortable: true,
+          key: "tags"
+        },
+        {
+          title: "Notes",
+          align: "start",
+          sortable: true,
+          key: "note"
+        },
+        {
+          align: "start",
+          sortable: false,
+          key: "actions"
+        }
+      ];
     },
+
     startsInFuture() {
       return isFuture(this.shift.started);
+    }
+  },
+  methods: {
+    isRunningShift(shift) {
+      return isWithinInterval(new Date(), {
+        start: shift.started,
+        end: shift.stopped
+      });
+    },
+    formattedDate(date) {
+      return localizedFormat(date, "EEEE',' do' 'MMMM");
+    },
+    formattedTime(time) {
+      return localizedFormat(time, "HH:mm");
+    },
+    formattedDuration(duration) {
+      return minutesToHHMM(duration, "");
+    },
+    noteDisplay(note, maxlength) {
+      if (note.length > maxlength) {
+        return note.substr(0, maxlength) + "...";
+      } else return note;
+    },
+    sortByDate(items, sortBy, sortDesc) {
+      const desc = sortDesc[0] ? -1 : 1;
+      items.sort((a, b) => {
+        switch (sortBy[0]) {
+          case "date":
+            return isBefore(b.started, a.started) ? -desc : desc;
+          case "start":
+            return isBefore(getHours(b.started), getHours(a.started))
+              ? -desc
+              : desc;
+          default:
+            return a[sortBy[0]] > b[sortBy[0]] ? -desc : desc;
+        }
+      });
+      return items;
+    },
+    // async destroy() {
+    //   const promises = [];
+    //   try {
+    //     for (const shift of this.selected) {
+    //       promises.push(ShiftService.delete(shift.id));
+    //     }
+    //
+    //     await Promise.all(promises);
+    //
+    //     this.$emit("refresh");
+    //     this.reset();
+    //   } catch (error) {
+    //     // TODO: Set error state for component & allow user to reload page
+    //     // We usually should end up here, if we are already logging out.
+    //     // But a proper error state could mitigate further issues.
+    //     log(error);
+    //   }
+    // },
+
+    async reviewSingleShift(shift) {
+      try {
+        const payload = shift.toPayload();
+        payload.was_reviewed = true;
+        await this.$store.dispatch("contentData/updateShift", {
+          payload,
+          initialContract: payload.contract
+        });
+      } catch (error) {
+        // TODO: Set error state for component & allow user to reload page
+        // We usually should end up here, if we are already logging out.
+        // But a proper error state could mitigate further issues.
+        log(error);
+      }
     }
   }
 };

--- a/src/mixins/breakpointsMixin.js
+++ b/src/mixins/breakpointsMixin.js
@@ -6,10 +6,10 @@ export default {
     smAndDown() {
       return this.$vuetify.display.smAndDown;
     },
-    isMobile() {
+    mobile() {
       return this.$vuetify.display.mobile;
     },
-    isXs() {
+    xs() {
       return this.$vuetify.display.xs;
     }
   }

--- a/src/mixins/breakpointsMixin.js
+++ b/src/mixins/breakpointsMixin.js
@@ -1,0 +1,48 @@
+export default {
+  computed: {
+    smAndUp() {
+      return this.$vuetify.display.smAndUp;
+    },
+    smAndDown() {
+      return this.$vuetify.display.smAndDown;
+    }
+
+    /*isXsOnly() {
+        return this.$vuetify.display.xsOnly;
+      },
+      smOnly() {
+        return this.$vuetify.display.smOnly;
+      },
+      mdOnly() {
+        return this.$vuetify.display.mdOnly;
+      },
+      lgOnly() {
+        return this.$vuetify.display.lgOnly;
+      },
+      xlOnly() {
+        return this.$vuetify.display.xlOnly;
+      },
+      xsAndUp() {
+        return this.$vuetify.display.xsAndUp;
+      },
+      
+      mdAndUp() {
+        return this.$vuetify.display.mdAndUp;
+      },
+      lgAndUp() {
+        return this.$vuetify.display.lgAndUp;
+      },
+      xlAndUp() {
+        return this.$vuetify.display.xlAndUp;
+      },
+      xsAndDown() {
+        return this.$vuetify.display.xsAndDown;
+      },
+      mdAndDown() {
+        return this.$vuetify.display.mdAndDown;
+      },
+      lgAndDown() {
+        return this.$vuetify.display.lgAndDown;
+      },*/
+  }
+};

--- a/src/mixins/breakpointsMixin.js
+++ b/src/mixins/breakpointsMixin.js
@@ -5,44 +5,12 @@ export default {
     },
     smAndDown() {
       return this.$vuetify.display.smAndDown;
+    },
+    isMobile() {
+      return this.$vuetify.display.mobile;
+    },
+    isXs() {
+      return this.$vuetify.display.xs;
     }
-
-    /*isXsOnly() {
-        return this.$vuetify.display.xsOnly;
-      },
-      smOnly() {
-        return this.$vuetify.display.smOnly;
-      },
-      mdOnly() {
-        return this.$vuetify.display.mdOnly;
-      },
-      lgOnly() {
-        return this.$vuetify.display.lgOnly;
-      },
-      xlOnly() {
-        return this.$vuetify.display.xlOnly;
-      },
-      xsAndUp() {
-        return this.$vuetify.display.xsAndUp;
-      },
-      
-      mdAndUp() {
-        return this.$vuetify.display.mdAndUp;
-      },
-      lgAndUp() {
-        return this.$vuetify.display.lgAndUp;
-      },
-      xlAndUp() {
-        return this.$vuetify.display.xlAndUp;
-      },
-      xsAndDown() {
-        return this.$vuetify.display.xsAndDown;
-      },
-      mdAndDown() {
-        return this.$vuetify.display.mdAndDown;
-      },
-      lgAndDown() {
-        return this.$vuetify.display.lgAndDown;
-      },*/
   }
 };

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -8,56 +8,6 @@ import {
 
 const { t } = i18n.global;
 
-export const SHIFT_TABLE_HEADERS = [
-  {
-    title: t("time.date"),
-    align: "start",
-    sortable: true,
-    key: "date"
-  },
-  {
-    title: t("time.start"),
-    align: "start",
-    sortable: true,
-    key: "start"
-  },
-  {
-    title: t("time.duration"),
-    align: "start",
-    sortable: true,
-    key: "duration"
-  },
-  {
-    title: t("calendar.type"),
-    align: "start",
-    sortable: true,
-    key: "type"
-  },
-  {
-    title: t("time.reviewed"),
-    align: "start",
-    sortable: true,
-    key: "reviewed"
-  },
-  {
-    title: "Tags",
-    align: "start",
-    sortable: true,
-    key: "tags"
-  },
-  {
-    title: "Notes",
-    align: "start",
-    sortable: true,
-    key: "note"
-  },
-  {
-    align: "start",
-    sortable: false,
-    key: "actions"
-  }
-];
-
 export const MESSAGE_TYPE_TAGS = {
   CL: t("news.label.changelog"),
   NO: t("news.label.notice"),

--- a/src/views/ViewShifts.vue
+++ b/src/views/ViewShifts.vue
@@ -75,6 +75,9 @@
 
                     <v-card-text>
                       {{ $t("shifts.table.pastShiftsHint") }}
+                      (<v-icon color="success">{{ icons.mdiCheck }}</v-icon
+                      >/<v-icon color="error">{{ icons.mdiClose }}</v-icon
+                      >).
                     </v-card-text>
                     <ShiftBulkActions
                       v-if="selected.length > 0"
@@ -164,7 +167,7 @@ import ShiftFormDialog from "@/components/forms/dialogs/ShiftFormDialog.vue";
 
 import { mapGetters } from "vuex";
 
-import { mdiMagnify } from "@mdi/js";
+import { mdiMagnify, mdiCheck, mdiClose } from "@mdi/js";
 import { isFuture, isPast, isSameMonth } from "date-fns";
 
 import { firstOfCurrentMonth, localizedFormat } from "@/utils/date";
@@ -181,7 +184,7 @@ export default {
     ShiftsTable
   },
   data: () => ({
-    icons: { mdiMagnify },
+    icons: { mdiMagnify, mdiCheck, mdiClose },
     date: firstOfCurrentMonth,
     loading: false,
     shiftEntity: null,


### PR DESCRIPTION
closes issue #286 .in the mobile view i showed only Date ,start ,duration ,type and removed the checkbox from the table .i also added an information and edit icon at the top of the table and both are only active if only one shift is selected  .When the info icon is clicked , a  new dialog will open and display all the informations about  the shift 
![Bildschirmfoto am 2024-12-28 um 14 40 07](https://github.com/user-attachments/assets/6d3d0f25-e865-401c-aad2-f7b0d1b558d9)
![Bildschirmfoto am 2024-12-28 um 14 40 14](https://github.com/user-attachments/assets/bbf762a5-5c14-4d7d-bf0d-79f143699665)


