### PR TITLE
Fix Overtime warning

### DIFF
--- a/src/views/Reporting.vue
+++ b/src/views/Reporting.vue
@@ -210,8 +210,9 @@ export default {
         );
         let report = filteredReports[0];
         if (report === undefined) {
-          this.date =
-            this.selectedReports[this.selectedReports.length - 1].monthYear;
+          this.date = this.selectedReports[
+            this.selectedReports.length - 1
+          ].monthYear;
           return;
         }
         this.report = report;
@@ -243,8 +244,7 @@ export default {
     getAlertMessages(report) {
       if (this.disabled) return [];
       let messages = [];
-      const worktimeInMinutes =
-        report.worktimeInMinutes + report.carryoverPreviousMonthInMinutes;
+      const worktimeInMinutes = report.worktimeInMinutes;
       const debitInMinutes = report.debitWorktimeInMinutes;
 
       if ((worktimeInMinutes / debitInMinutes) * 100 > 150) {


### PR DESCRIPTION
The condition for display of overtime warning already accounted for the previous months carryover.
In case of negative previous carryover this caused the warning to not displayed.